### PR TITLE
Feature/misc fixes

### DIFF
--- a/packages/unmutable-core/package.json
+++ b/packages/unmutable-core/package.json
@@ -25,7 +25,6 @@
     "babel-core": "^6.23.0",
     "babel-plugin-istanbul": "4.1.1",
     "babel-preset-blueflag": "^0.3.0",
-    "babel-register": "^6.23.0",
-    "immutable": "^3.8.1"
+    "babel-register": "^6.23.0"
   }
 }

--- a/packages/unmutable-core/package.json
+++ b/packages/unmutable-core/package.json
@@ -25,6 +25,7 @@
     "babel-core": "^6.23.0",
     "babel-plugin-istanbul": "4.1.1",
     "babel-preset-blueflag": "^0.3.0",
-    "babel-register": "^6.23.0"
+    "babel-register": "^6.23.0",
+    "immutable": "^3.8.1"
   }
 }

--- a/packages/unmutable-core/package.json
+++ b/packages/unmutable-core/package.json
@@ -20,9 +20,6 @@
     "prepublish": "yarn run build && cp ../../README.md ./README.md",
     "watch": "yarn run build -- -w"
   },
-  "dependencies": {
-    "is-plain-object": "^2.0.4"
-  },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.0",

--- a/packages/unmutable-core/src/IsKeyed-test.js
+++ b/packages/unmutable-core/src/IsKeyed-test.js
@@ -1,0 +1,23 @@
+// @flow
+import test from 'ava';
+import IsKeyed from './IsKeyed';
+
+test('is keyed should return true for keyed stuff', (tt: *) => {
+
+    tt.true(IsKeyed({}), "Plain object should be true");
+    tt.true(IsKeyed({foo: "bar"}), "Plain object with key should be true");
+    tt.true(IsKeyed(new Object()), "New object should be true");
+    tt.true(IsKeyed(Object.create({})), "Object.create should be true");
+    tt.true(IsKeyed(Object.create(Object.prototype)), "Object.create should be true");
+    tt.true(IsKeyed([]), "Arrays should be true (in reality we don't care about arrays)");
+
+    let FakeClass  = class FakeClass {};
+    tt.true(IsKeyed(new FakeClass()), "Class instances should be true");
+
+    tt.false(IsKeyed(undefined), "undefined should be false");
+    tt.false(IsKeyed(null), "null should be false");
+    tt.false(IsKeyed(1), "number should be false");
+    tt.false(IsKeyed("A"), "string should be false");
+    tt.false(IsKeyed(() => {}), "Function should be false");
+
+});

--- a/packages/unmutable-core/src/IsKeyed.js
+++ b/packages/unmutable-core/src/IsKeyed.js
@@ -1,0 +1,4 @@
+// @flow
+export default function IsKeyed(item: *): boolean {
+    return !!(item && typeof item === "object");
+}

--- a/packages/unmutable-core/src/index.js
+++ b/packages/unmutable-core/src/index.js
@@ -1,11 +1,7 @@
 // @flow
 
-export {default as IndexedTests} from './tests/IndexedTests-testUtil';
-export {default as KeyedTests} from './tests/KeyedTests-testUtil';
-export {default as WrapTests} from './tests/WrapTests-testUtil';
-
 export {default as CompositeMethods} from './CompositeMethods';
 export {default as CreateMethodConstructors} from './CreateMethodConstructors';
-export {default as IsPlainObject} from 'is-plain-object';
+export {default as IsKeyed} from './IsKeyed';
 export {default as ListMethodNames} from './ListMethodNames';
 export {default as MethodReturnTypes} from './MethodReturnTypes';

--- a/packages/unmutable-lite/package.json
+++ b/packages/unmutable-lite/package.json
@@ -29,7 +29,6 @@
     "babel-core": "^6.23.0",
     "babel-plugin-istanbul": "4.1.1",
     "babel-preset-blueflag": "^0.3.0",
-    "babel-register": "^6.23.0",
-    "immutable": "^3.8.1"
+    "babel-register": "^6.23.0"
   }
 }

--- a/packages/unmutable-lite/package.json
+++ b/packages/unmutable-lite/package.json
@@ -29,6 +29,7 @@
     "babel-core": "^6.23.0",
     "babel-plugin-istanbul": "4.1.1",
     "babel-preset-blueflag": "^0.3.0",
-    "babel-register": "^6.23.0"
+    "babel-register": "^6.23.0",
+    "immutable": "^3.8.1"
   }
 }

--- a/packages/unmutable-lite/src/Wrap.js
+++ b/packages/unmutable-lite/src/Wrap.js
@@ -1,6 +1,6 @@
 // @flow
 import {isMap, isList} from './ImmutablePredicates';
-import {IsPlainObject} from 'unmutable-core';
+import {IsKeyed} from 'unmutable-core';
 
 import UnmutableWrapper from './UnmutableWrapper';
 import UnmutableMapWrapper from './UnmutableMapWrapper';
@@ -9,17 +9,17 @@ import UnmutableObjectWrapper from './UnmutableObjectWrapper';
 import UnmutableArrayWrapper from './UnmutableArrayWrapper';
 
 export default function Wrap(item: *, options: Options = {}): UnmutableWrapperType {
-    if(IsPlainObject(item)) {
-        return new UnmutableObjectWrapper(item, options);
-    }
-    if(Array.isArray(item)) {
-        return new UnmutableArrayWrapper(item, options);
-    }
     if(isMap(item)) {
         return new UnmutableMapWrapper(item, options);
     }
     if(isList(item)) {
         return new UnmutableListWrapper(item, options);
+    }
+    if(Array.isArray(item)) {
+        return new UnmutableArrayWrapper(item, options);
+    }
+    if(IsKeyed(item)) {
+        return new UnmutableObjectWrapper(item, options);
     }
     return new UnmutableWrapper(item, options);
 }

--- a/packages/unmutable-lite/src/index-test.js
+++ b/packages/unmutable-lite/src/index-test.js
@@ -1,11 +1,9 @@
 // @flow
 import test from 'ava';
 import {Wrap} from './index';
-import {
-    IndexedTests,
-    KeyedTests,
-    WrapTests
-} from 'unmutable-core';
+import IndexedTests from 'unmutable-core/lib/tests/IndexedTests-testUtil';
+import KeyedTests from 'unmutable-core/lib/tests/KeyedTests-testUtil';
+import WrapTests from 'unmutable-core/lib/tests/WrapTests-testUtil';
 
 WrapTests(test, Wrap);
 

--- a/packages/unmutable/package.json
+++ b/packages/unmutable/package.json
@@ -32,6 +32,7 @@
     "babel-core": "^6.23.0",
     "babel-plugin-istanbul": "4.1.1",
     "babel-preset-blueflag": "^0.3.0",
-    "babel-register": "^6.23.0"
+    "babel-register": "^6.23.0",
+    "immutable": "^3.8.1"
   }
 }

--- a/packages/unmutable/src/Wrap.js
+++ b/packages/unmutable/src/Wrap.js
@@ -1,6 +1,6 @@
 // @flow
 import {Map, List} from 'immutable';
-import {IsPlainObject} from 'unmutable-core';
+import {IsKeyed} from 'unmutable-core';
 
 import UnmutableWrapper from './UnmutableWrapper';
 import UnmutableMapWrapper from './UnmutableMapWrapper';
@@ -9,17 +9,17 @@ import UnmutableObjectWrapper from './UnmutableObjectWrapper';
 import UnmutableArrayWrapper from './UnmutableArrayWrapper';
 
 export default function Wrap(item: *, options: Options = {}): UnmutableWrapperType {
-    if(IsPlainObject(item)) {
-        return new UnmutableObjectWrapper(item, options);
-    }
-    if(Array.isArray(item)) {
-        return new UnmutableArrayWrapper(item, options);
-    }
     if(Map.isMap(item)) {
         return new UnmutableMapWrapper(item, options);
     }
     if(List.isList(item)) {
         return new UnmutableListWrapper(item, options);
+    }
+    if(Array.isArray(item)) {
+        return new UnmutableArrayWrapper(item, options);
+    }
+    if(IsKeyed(item)) {
+        return new UnmutableObjectWrapper(item, options);
     }
     return new UnmutableWrapper(item, options);
 }

--- a/packages/unmutable/src/index-test.js
+++ b/packages/unmutable/src/index-test.js
@@ -1,11 +1,9 @@
 // @flow
 import test from 'ava';
 import {Wrap} from './index';
-import {
-    IndexedTests,
-    KeyedTests,
-    WrapTests
-} from 'unmutable-core';
+import IndexedTests from 'unmutable-core/lib/tests/IndexedTests-testUtil';
+import KeyedTests from 'unmutable-core/lib/tests/KeyedTests-testUtil';
+import WrapTests from 'unmutable-core/lib/tests/WrapTests-testUtil';
 
 WrapTests(test, Wrap);
 


### PR DESCRIPTION
- Provide a more accurate check for indexed data items
  - Class instances are now recognised as being keyed
  - Functions are still not recognised as being keyed because that's Immutable's stance. Can reconsider if we really want to break parity with their behaviour if it comes up again in future
- Removed dependency on `is-plain-object`
- Ordered `Wrap` checks from most specific to most general.

