### PR TITLE
Feature/extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ console.log(wrappedObject.getIn(['a', 'b']).value); // logs out "hi"
 
 ## Installation
 
-There are two packages you can choose from, `unmutable` or `unmutable-lite`.
+There are two main packages you can choose from, `unmutable` or `unmutable-lite`. There is also an optional package of extra functions called `unmutable-extra`.
 
 ### unmutable
 
@@ -59,6 +59,10 @@ or
 ```bash
 npm install unmutable-lite
 ```
+
+### unmutable-extra
+
+This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable Extra).
 
 ## More examples
 
@@ -157,9 +161,9 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | entries | entries | entries | entries ||
 | entrySeq | entrySeq | entrySeq | entrySeq ||
 | equals | equals | equals | equals ||
-| **every** ✔︎ | **every** ✔︎ | every | **every** ✔︎ | Returns plain boolean |
-| **filter** ✔︎ | **filter** ✔︎ | filter | filter ||
-| **filterNot** ✔︎ | **filterNot** ✔︎ | filterNot | filterNot ||
+| **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | Returns plain boolean |
+| **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ ||
+| **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ ||
 | find | find | find | find ||
 | findEntry | findEntry | findEntry | findEntry ||
 | - | findIndex | - | findIndex ||
@@ -191,7 +195,8 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | join | join | join | join ||
 | keyOf | keyOf | keyOf | keyOf ||
 | keys | keys | keys | keys ||
-| keySeq | keySeq | keySeq | keySeq ||
+| keyList | keyList | keyList | keyList | Returns keys as an array, this doesn't exist in Immutable.js |
+| keySeq | keySeq | - | - ||
 | **last** ✔︎ | **last** ✔︎ | - | **last** ✔︎ ||
 | - | lastIndexOf | - | lastIndexOf ||
 | lastKeyOf | lastKeyOf | lastKeyOf | lastKeyOf ||
@@ -222,7 +227,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **skipUntil** ✔︎ | **skipUntil** ✔︎ | - | skipUntil ||
 | **skipWhile** ✔︎ | **skipWhile** ✔︎ | - | skipWhile ||
 | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ ||
-| **some** ✔︎ | **some** ✔︎ | some | **some** ✔︎ | Returns plain boolean |
+| **some** ✔︎ | **some** ✔︎ | **some** ✔︎  | **some** ✔︎ | Returns plain boolean |
 | **sort** ✔︎ | **sort** ✔︎ | sort | sort ||
 | **sortBy** ✔︎ | **sortBy** ✔︎ | sortBy | sortBy ||
 | - | splice | - | splice ||
@@ -253,5 +258,74 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | - | zip | - | zip ||
 | - | zipWith | - | zipWith ||
 
+## Unmutable Extra
 
+This package contains optional extra functions for unmutable that don't exist in Immutable.js.
 
+```bash
+yarn add unmutable-extra
+```
+
+or 
+
+```bash
+npm install unmutable-extra
+```
+
+Functions in this package use partially applied functions, which allow for easy chaining by using them inside of an `update()` method:
+
+```js
+return Wrap([1,2,3])
+    .update(pivot()) // using a pivot in a chain
+    .map(doOtherStuff)
+    .value
+```
+
+### API
+
+#### pivot
+`pivot() => (UnmutableWrapper)`
+
+Takes a collection that is 2 layers deep and flips the contents of each layer, in the same way that you might pivot a spreadsheet to turn rows into columns and vice versa. Works with any combination of Objects, Arrays, Maps and Lists.
+
+```js
+import {pivot} from 'unmutable-extra';
+
+return Wrap([
+    [1,2,3],
+    [4,5,6]
+])
+    .update(pivot())
+    .value;
+
+// Returns:
+// [
+//     [1,4],
+//     [2,5],
+//     [3,6]
+// ]
+
+return Wrap({
+    a: {
+        x: 1,
+        y: 2
+    },
+    b: {
+        x: 3
+    }
+})
+    .update(pivot())
+    .value;
+
+// Returns:
+// {
+//     x: {
+//         a: 1,
+//         b: 3
+//     },
+//     y: {
+//         a: 1
+//     }
+// }
+
+```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm install unmutable-lite
 
 ### unmutable-extra
 
-This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable Extra).
+This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable-Extra).
 
 ## More examples
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "lerna run build",
     "postinstall": "lerna bootstrap",
-    "prepublish": "cp README.md packages/unmutable && cp README.md packages/unmutable-lite && lerna run prepublish",
+    "prepublish": "cp README.md packages/unmutable && cp README.md packages/unmutable-lite && cp README.md packages/unmutable-extra && lerna run prepublish",
     "watch": "lerna run --parallel watch",
     "ava": "NODE_ENV=test ava",
     "check-coverage": "NODE_ENV=test nyc check-coverage --branches 100.0  --functions 100.0 --lines 100.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
       "packages/unmutable-core/src/AddMethods.js",
       "packages/unmutable-core/src/CompositeMethods.js",
       "packages/unmutable-core/src/IsUnmutable.js",
+      "packages/unmutable-core/src/KeyArray.js",
       "packages/unmutable-core/src/Unwrap.js",
       "dist"
     ],

--- a/packages/unmutable-core/README.md
+++ b/packages/unmutable-core/README.md
@@ -25,7 +25,7 @@ console.log(wrappedObject.getIn(['a', 'b']).value); // logs out "hi"
 
 ## Installation
 
-There are two packages you can choose from, `unmutable` or `unmutable-lite`.
+There are two main packages you can choose from, `unmutable` or `unmutable-lite`. There is also an optional package of extra functions called `unmutable-extra`.
 
 ### unmutable
 
@@ -59,6 +59,10 @@ or
 ```bash
 npm install unmutable-lite
 ```
+
+### unmutable-extra
+
+This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable-Extra).
 
 ## More examples
 
@@ -157,9 +161,9 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | entries | entries | entries | entries ||
 | entrySeq | entrySeq | entrySeq | entrySeq ||
 | equals | equals | equals | equals ||
-| **every** ✔︎ | **every** ✔︎ | every | **every** ✔︎ | Returns plain boolean |
-| **filter** ✔︎ | **filter** ✔︎ | filter | filter ||
-| **filterNot** ✔︎ | **filterNot** ✔︎ | filterNot | filterNot ||
+| **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | Returns plain boolean |
+| **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ ||
+| **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ ||
 | find | find | find | find ||
 | findEntry | findEntry | findEntry | findEntry ||
 | - | findIndex | - | findIndex ||
@@ -178,7 +182,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ ||
 | groupBy | groupBy | groupBy | groupBy ||
 | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | Returns plain boolean |
-| hashCode | hashCode | hashCode | hashCode ||
+| hashCode | hashCode | - | - ||
 | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | Returns plain boolean |
 | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | Returns plain boolean |
 | - | indexOf | - | indexOf ||
@@ -191,7 +195,8 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | join | join | join | join ||
 | keyOf | keyOf | keyOf | keyOf ||
 | keys | keys | keys | keys ||
-| keySeq | keySeq | keySeq | keySeq ||
+| keyList | keyList | keyList | keyList | Returns keys as an array, this doesn't exist in Immutable.js |
+| keySeq | keySeq | - | - ||
 | **last** ✔︎ | **last** ✔︎ | - | **last** ✔︎ ||
 | - | lastIndexOf | - | lastIndexOf ||
 | lastKeyOf | lastKeyOf | lastKeyOf | lastKeyOf ||
@@ -222,7 +227,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **skipUntil** ✔︎ | **skipUntil** ✔︎ | - | skipUntil ||
 | **skipWhile** ✔︎ | **skipWhile** ✔︎ | - | skipWhile ||
 | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ ||
-| **some** ✔︎ | **some** ✔︎ | some | **some** ✔︎ | Returns plain boolean |
+| **some** ✔︎ | **some** ✔︎ | **some** ✔︎  | **some** ✔︎ | Returns plain boolean |
 | **sort** ✔︎ | **sort** ✔︎ | sort | sort ||
 | **sortBy** ✔︎ | **sortBy** ✔︎ | sortBy | sortBy ||
 | - | splice | - | splice ||
@@ -231,19 +236,19 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **takeUntil** ✔︎ | **takeUntil** ✔︎ | - | takeUntil ||
 | **takeWhile** ✔︎ | **takeWhile** ✔︎ | - | takeWhile ||
 | toArray | toArray | toArray | toArray ||
-| toIndexedSeq | toIndexedSeq | toIndexedSeq | toIndexedSeq ||
+| toIndexedSeq | toIndexedSeq | - | - ||
 | toJS | toJS | toJS | toJS ||
 | toJSON | toJSON | toJSON | toJSON ||
-| toKeyedSeq | toKeyedSeq | toKeyedSeq | toKeyedSeq ||
-| toList | toList | toList | toList ||
-| toMap | toMap | toMap | toMap ||
+| toKeyedSeq | toKeyedSeq | - | - ||
+| toList | toList | - | - ||
+| toMap | toMap | - | - ||
 | toObject | toObject | toObject | toObject ||
-| toOrderedMap | toOrderedMap | toOrderedMap | toOrderedMap ||
-| toOrderedSet | toOrderedSet | toOrderedSet | toOrderedSet ||
-| toSeq | toSeq | toSeq | toSeq ||
-| toSet | toSet | toSet | toSet ||
-| toSetSeq | toSetSeq | toSetSeq | toSetSeq ||
-| toStack | toStack | toStack | toStack ||
+| toOrderedMap | toOrderedMap | - | - ||
+| toOrderedSet | toOrderedSet | - | - ||
+| toSeq | toSeq | - | - ||
+| toSet | toSet | - | - ||
+| toSetSeq | toSetSeq | - | - ||
+| toStack | toStack | - | - ||
 | - | **unshift** ✔︎ | - | **unshift** ✔︎ ||
 | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ ||
 | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ ||
@@ -253,5 +258,74 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | - | zip | - | zip ||
 | - | zipWith | - | zipWith ||
 
+## Unmutable Extra
 
+This package contains optional extra functions for unmutable that don't exist in Immutable.js.
 
+```bash
+yarn add unmutable-extra
+```
+
+or 
+
+```bash
+npm install unmutable-extra
+```
+
+Functions in this package use partially applied functions, which allow for easy chaining by using them inside of an `update()` method:
+
+```js
+return Wrap([1,2,3])
+    .update(pivot()) // using a pivot in a chain
+    .map(doOtherStuff)
+    .value
+```
+
+### API
+
+#### pivot
+`pivot() => (UnmutableWrapper)`
+
+Takes a collection that is 2 layers deep and flips the contents of each layer, in the same way that you might pivot a spreadsheet to turn rows into columns and vice versa. Works with any combination of Objects, Arrays, Maps and Lists.
+
+```js
+import {pivot} from 'unmutable-extra';
+
+return Wrap([
+    [1,2,3],
+    [4,5,6]
+])
+    .update(pivot())
+    .value;
+
+// Returns:
+// [
+//     [1,4],
+//     [2,5],
+//     [3,6]
+// ]
+
+return Wrap({
+    a: {
+        x: 1,
+        y: 2
+    },
+    b: {
+        x: 3
+    }
+})
+    .update(pivot())
+    .value;
+
+// Returns:
+// {
+//     x: {
+//         a: 1,
+//         b: 3
+//     },
+//     y: {
+//         a: 1
+//     }
+// }
+
+```

--- a/packages/unmutable-core/src/AddMethods.js
+++ b/packages/unmutable-core/src/AddMethods.js
@@ -123,9 +123,7 @@ const methods: Object = {
     reduce: {
         fn: ({method, wrap, self}: FnParams): Function => (iterate: Function, initialReduction: *): * => {
             return method(
-                (reduction, value, key) => Unwrap(
-                    iterate(reduction, wrap(value), key, self)
-                ),
+                (reduction, value, key) => iterate(reduction, wrap(value), key, self),
                 initialReduction
             );
         },
@@ -134,9 +132,7 @@ const methods: Object = {
     reduceRight: {
         fn: ({method, wrap, self}: FnParams): Function => (iterate: Function, initialReduction: *): * => {
             return method(
-                (reduction, value, key) => Unwrap(
-                    iterate(reduction, wrap(value), key, self)
-                ),
+                (reduction, value, key) => iterate(reduction, wrap(value), key, self),
                 initialReduction
             );
         },
@@ -149,11 +145,14 @@ const methods: Object = {
         returnType: "self"
     },
     set: {
+        fn: ({method}: FnParams): Function => (key: string, value: *): * => {
+            return method(key, Unwrap(value));
+        },
         returnType: "self"
     },
     setIn: {
         fn: ({wrap, self, toWrapperData}: FnParams): Function => (keyPath: Array<string>, value: *): * => {
-            return setIn(self, wrap)(keyPath, value, () => toWrapperData({}));
+            return setIn(self, wrap)(keyPath, Unwrap(value), () => toWrapperData({}));
         },
         returnType: "plain"
     },

--- a/packages/unmutable-core/src/AddMethods.js
+++ b/packages/unmutable-core/src/AddMethods.js
@@ -1,6 +1,7 @@
 // @flow
 import ListMethodNames from './ListMethodNames';
 import CompositeMethods from './CompositeMethods';
+import KeyArray from './KeyArray';
 import Unwrap from './Unwrap';
 const {deleteIn, getIn, hasIn, setIn, updateIn} = CompositeMethods;
 
@@ -94,6 +95,12 @@ const methods: Object = {
     },
     isEmpty: {
         returnType: "plain"
+    },
+    keyArray: {
+        fn: ({self}: FnParams): Function => (): * => {
+            return KeyArray(self);
+        },
+        returnType: "wrapped"
     },
     last: {
         returnType: "wrapped"

--- a/packages/unmutable-core/src/KeyArray.js
+++ b/packages/unmutable-core/src/KeyArray.js
@@ -1,0 +1,21 @@
+// @flow
+export default function KeyArray(self: UnmutableWrapperType): Array<number|string> {
+    if(self.value.keySeq) {
+        return self
+            .value
+            .keySeq()
+            .toArray();
+    }
+    let keys: Array<string|number> = [];
+    if(Array.isArray(self.value)) {
+        let {size} = self;
+        for(let i = 0; i < size; i++) {
+            keys.push(i);
+        }
+        return keys;
+    }
+    for(var key in self.value) {
+        keys.push(key);
+    }
+    return keys;
+}

--- a/packages/unmutable-core/src/tests/IndexedTests-testUtil.js
+++ b/packages/unmutable-core/src/tests/IndexedTests-testUtil.js
@@ -24,6 +24,11 @@ export default function(test: Function, Wrap: Function, indexedTests: Array<Obje
         tt.is(Wrap(list).size, list.size, 'size returns correct size');
     });
 
+    test('Wrapped Lists have a keyArray method', (tt: *) => {
+        var list: List<*> = fromJS(sampleArray);
+        tt.deepEqual(Wrap(list).keyArray().value, [0,1,2], 'keyArray returns correct array of keys');
+    });
+
     CollectionTestDefinitions({
         existingValue: 2,
         item: fromJS(sampleArray),
@@ -77,6 +82,10 @@ export default function(test: Function, Wrap: Function, indexedTests: Array<Obje
 
     test('Arrays have a size', (tt: *) => {
         tt.is(Wrap(sampleArray).size, List(sampleArray).size, 'size returns correct size');
+    });
+
+    test('Wrapped Array have a keyArray method', (tt: *) => {
+        tt.deepEqual(Wrap(sampleArray).keyArray().value, [0,1,2], 'keyArray returns correct array of keys');
     });
 
     CollectionTestDefinitions({

--- a/packages/unmutable-core/src/tests/KeyedTests-testUtil.js
+++ b/packages/unmutable-core/src/tests/KeyedTests-testUtil.js
@@ -140,7 +140,7 @@ export default function(test: Function, Wrap: Function, keyedTests: Array<Object
                     unmutableResult = unmutableResult.value;
                 }
 
-                tt.deepEqual(mapResult, unmutableResult, "Result shoud be correct");
+                tt.deepEqual(mapResult, unmutableResult, "Result should be correct");
                 if(testForImmutability && shouldBeImmutable) {
                     tt.not(item, unmutableResult, "Method should be immutable");
                 }

--- a/packages/unmutable-core/src/tests/KeyedTests-testUtil.js
+++ b/packages/unmutable-core/src/tests/KeyedTests-testUtil.js
@@ -44,6 +44,11 @@ export default function(test: Function, Wrap: Function, keyedTests: Array<Object
         tt.is(Wrap(map).size, map.size, 'size returns correct size');
     });
 
+    test('Wrapped Maps have a keyArray method', (tt: *) => {
+        var map: Map<string,*> = fromJS(sampleObject);
+        tt.deepEqual(Wrap(map).keyArray().value, ['a','b','c'], 'keyArray returns correct array of keys');
+    });
+
     CollectionTestDefinitions({
         ...testDefinitions,
         item: fromJS(sampleObject),
@@ -83,6 +88,10 @@ export default function(test: Function, Wrap: Function, keyedTests: Array<Object
 
     test('Objects have a size', (tt: *) => {
         tt.is(Wrap(sampleObject).size, Map(sampleObject).size, 'size returns correct size');
+    });
+
+    test('Wrapped Objects have a keyArray method', (tt: *) => {
+        tt.deepEqual(Wrap(sampleObject).keyArray().value, ['a','b','c'], 'keyArray returns correct array of keys');
     });
 
     CollectionTestDefinitions({

--- a/packages/unmutable-core/src/tests/UnwrapTests-testUtil.js
+++ b/packages/unmutable-core/src/tests/UnwrapTests-testUtil.js
@@ -25,4 +25,18 @@ export default function(test: Function, Wrap: Function) {
         tt.is(Unwrap(Wrap(1)), 1, "number should be unwrapped");
         tt.is(Unwrap(Wrap("A")), "A", "string should be unwrapped");
     });
+
+    test('.set() should unwrap value', (tt: *) => {
+        tt.deepEqual(
+            Wrap({a: 1}).set('b', Wrap(2)).value,
+            {a: 1, b: 2}
+        );
+    });
+
+    test('.setIn() should unwrap value', (tt: *) => {
+        tt.deepEqual(
+            Wrap({a: 1}).setIn(['b'], Wrap(2)).value,
+            {a: 1, b: 2}
+        );
+    });
 }

--- a/packages/unmutable-extra/README.md
+++ b/packages/unmutable-extra/README.md
@@ -25,7 +25,7 @@ console.log(wrappedObject.getIn(['a', 'b']).value); // logs out "hi"
 
 ## Installation
 
-There are two packages you can choose from, `unmutable` or `unmutable-lite`.
+There are two main packages you can choose from, `unmutable` or `unmutable-lite`. There is also an optional package of extra functions called `unmutable-extra`.
 
 ### unmutable
 
@@ -59,6 +59,10 @@ or
 ```bash
 npm install unmutable-lite
 ```
+
+### unmutable-extra
+
+This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable-Extra).
 
 ## More examples
 
@@ -157,9 +161,9 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | entries | entries | entries | entries ||
 | entrySeq | entrySeq | entrySeq | entrySeq ||
 | equals | equals | equals | equals ||
-| **every** ✔︎ | **every** ✔︎ | every | **every** ✔︎ | Returns plain boolean |
-| **filter** ✔︎ | **filter** ✔︎ | filter | filter ||
-| **filterNot** ✔︎ | **filterNot** ✔︎ | filterNot | filterNot ||
+| **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | Returns plain boolean |
+| **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ ||
+| **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ ||
 | find | find | find | find ||
 | findEntry | findEntry | findEntry | findEntry ||
 | - | findIndex | - | findIndex ||
@@ -178,7 +182,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ ||
 | groupBy | groupBy | groupBy | groupBy ||
 | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | Returns plain boolean |
-| hashCode | hashCode | hashCode | hashCode ||
+| hashCode | hashCode | - | - ||
 | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | Returns plain boolean |
 | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | Returns plain boolean |
 | - | indexOf | - | indexOf ||
@@ -191,7 +195,8 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | join | join | join | join ||
 | keyOf | keyOf | keyOf | keyOf ||
 | keys | keys | keys | keys ||
-| keySeq | keySeq | keySeq | keySeq ||
+| keyList | keyList | keyList | keyList | Returns keys as an array, this doesn't exist in Immutable.js |
+| keySeq | keySeq | - | - ||
 | **last** ✔︎ | **last** ✔︎ | - | **last** ✔︎ ||
 | - | lastIndexOf | - | lastIndexOf ||
 | lastKeyOf | lastKeyOf | lastKeyOf | lastKeyOf ||
@@ -222,7 +227,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **skipUntil** ✔︎ | **skipUntil** ✔︎ | - | skipUntil ||
 | **skipWhile** ✔︎ | **skipWhile** ✔︎ | - | skipWhile ||
 | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ ||
-| **some** ✔︎ | **some** ✔︎ | some | **some** ✔︎ | Returns plain boolean |
+| **some** ✔︎ | **some** ✔︎ | **some** ✔︎  | **some** ✔︎ | Returns plain boolean |
 | **sort** ✔︎ | **sort** ✔︎ | sort | sort ||
 | **sortBy** ✔︎ | **sortBy** ✔︎ | sortBy | sortBy ||
 | - | splice | - | splice ||
@@ -231,19 +236,19 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **takeUntil** ✔︎ | **takeUntil** ✔︎ | - | takeUntil ||
 | **takeWhile** ✔︎ | **takeWhile** ✔︎ | - | takeWhile ||
 | toArray | toArray | toArray | toArray ||
-| toIndexedSeq | toIndexedSeq | toIndexedSeq | toIndexedSeq ||
+| toIndexedSeq | toIndexedSeq | - | - ||
 | toJS | toJS | toJS | toJS ||
 | toJSON | toJSON | toJSON | toJSON ||
-| toKeyedSeq | toKeyedSeq | toKeyedSeq | toKeyedSeq ||
-| toList | toList | toList | toList ||
-| toMap | toMap | toMap | toMap ||
+| toKeyedSeq | toKeyedSeq | - | - ||
+| toList | toList | - | - ||
+| toMap | toMap | - | - ||
 | toObject | toObject | toObject | toObject ||
-| toOrderedMap | toOrderedMap | toOrderedMap | toOrderedMap ||
-| toOrderedSet | toOrderedSet | toOrderedSet | toOrderedSet ||
-| toSeq | toSeq | toSeq | toSeq ||
-| toSet | toSet | toSet | toSet ||
-| toSetSeq | toSetSeq | toSetSeq | toSetSeq ||
-| toStack | toStack | toStack | toStack ||
+| toOrderedMap | toOrderedMap | - | - ||
+| toOrderedSet | toOrderedSet | - | - ||
+| toSeq | toSeq | - | - ||
+| toSet | toSet | - | - ||
+| toSetSeq | toSetSeq | - | - ||
+| toStack | toStack | - | - ||
 | - | **unshift** ✔︎ | - | **unshift** ✔︎ ||
 | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ ||
 | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ ||
@@ -253,5 +258,74 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | - | zip | - | zip ||
 | - | zipWith | - | zipWith ||
 
+## Unmutable Extra
 
+This package contains optional extra functions for unmutable that don't exist in Immutable.js.
 
+```bash
+yarn add unmutable-extra
+```
+
+or 
+
+```bash
+npm install unmutable-extra
+```
+
+Functions in this package use partially applied functions, which allow for easy chaining by using them inside of an `update()` method:
+
+```js
+return Wrap([1,2,3])
+    .update(pivot()) // using a pivot in a chain
+    .map(doOtherStuff)
+    .value
+```
+
+### API
+
+#### pivot
+`pivot() => (UnmutableWrapper)`
+
+Takes a collection that is 2 layers deep and flips the contents of each layer, in the same way that you might pivot a spreadsheet to turn rows into columns and vice versa. Works with any combination of Objects, Arrays, Maps and Lists.
+
+```js
+import {pivot} from 'unmutable-extra';
+
+return Wrap([
+    [1,2,3],
+    [4,5,6]
+])
+    .update(pivot())
+    .value;
+
+// Returns:
+// [
+//     [1,4],
+//     [2,5],
+//     [3,6]
+// ]
+
+return Wrap({
+    a: {
+        x: 1,
+        y: 2
+    },
+    b: {
+        x: 3
+    }
+})
+    .update(pivot())
+    .value;
+
+// Returns:
+// {
+//     x: {
+//         a: 1,
+//         b: 3
+//     },
+//     y: {
+//         a: 1
+//     }
+// }
+
+```

--- a/packages/unmutable-extra/README.md
+++ b/packages/unmutable-extra/README.md
@@ -1,0 +1,257 @@
+# unmutable
+
+*Immutable.js functions for collections that may or may not be Immutable.*
+
+Immutable.js has a fantastic API, but sometimes you don't want to turn everything into Immutable collections. With large nested data structures, Immutable can be quite heavy on memory and slow, and you may need to cope with data that might sometimes contain immutable collections and sometimes not.
+
+This project aims to bring that API over for use with plain objects and arrays, as well as Immutable.js `Map` and `List` collections. Like Immutable.jsm, unmutable never mutates data. Unlike Immutable.js, unmutable constructs nested data objects lazily, so when using nested data sets its memory footprint is much smaller than Immutable.js.
+
+### Quick example
+
+`Wrap` will wrap your data in an `UnmutableWrapper`. You can then use Immutable.js style methods on it, then access `.value` when you want to get the contents of your wrapper back out again.
+
+```js
+import {Wrap} from 'unmutable';
+
+var wrappedObject = Wrap({
+    a: {
+        b: "hi"
+    }
+})
+
+console.log(wrappedObject.getIn(['a', 'b']).value); // logs out "hi"
+
+```
+
+## Installation
+
+There are two packages you can choose from, `unmutable` or `unmutable-lite`.
+
+### unmutable
+
+Unmutable requires `immutable@v3.8.1` as a peer depencency, and will allow you to use almost all of Immutable.js' methods on your Unmutable collections. Use this if you already have Immutable.js as a dependency or want to take advantage of Immutable.js' large set of `Map` and `List` features on objects and arrays.
+
+Refer to the [Methods](#Methods) section to see which methods you can use on Unmutable collections.
+
+
+```bash
+yarn add immutable && yarn add unmutable
+```
+
+or 
+
+```bash
+npm install immutable && npm install unmutable
+```
+
+### unmutable-lite
+
+Unmutable-lite is a standalone library that allows you to use a subset of Immutable.js' methods on objects and arrays, and on Immutable.js collections. Use this if you like Immutable.js' API but don't want the Immutable.js dependency.
+
+Refer to the [Methods](#Methods) section to see which methods you can use on Unmutable-lite collections.
+
+```bash
+yarn add unmutable-lite
+```
+
+or 
+
+```bash
+npm install unmutable-lite
+```
+
+## More examples
+
+Data types are preserved through the wrapping process. Pass in an object and you'll get back an object. Pass in a `Map`? You'll get a `Map` back. Same goes for Arrays vs `Lists`.
+
+```js
+import {Wrap} from 'unmutable';
+import {Map} from 'immutable';
+
+var obj = {abc: 123};
+var newObj = Wrap(obj).set('abc', 456)value;
+// newObj is an object {abc: 456}
+
+var map = Map({abc: 123});
+var newMap = Wrap(map).set('abc', 456)value;
+// newMap is a Map {abc: 456}
+
+```
+
+`Wrap` can actually wrap around any data type, not just collections. If your data isn't a collection then you won't be able to use any collection manipulation methods, but you will be able to access the wrapper's `.value` property and the methods `isCollection()`, `isKeyed()` and `isIndexed()`.
+
+Please note that while you *can* wrap Immutable collections other than `Map` and `List`, right now they won't be recognised as collections so you won't be able to access their methods on the Unmutable wrapper. As this library grows, the plan is to bring in more Immutable types.
+
+```js
+import {Wrap} from 'unmutable';
+
+console.log(Wrap("string")value); // logs out "string"
+console.log(Wrap("string").isCollection()); // false
+```
+
+## Helper functions
+
+Unmutable exports the following helper functions:
+- `IsUnmutable` - Pass it anything and it'll return a boolean, true if the passed item is an unmutable wrapper of some kind.
+- `Unwrap` - Unmutable wrappers passed into this will be unwrapped, everything else will just pass through unchanged.
+
+## Methods
+
+All unmutable wrappers will have the following member variables and methods:
+
+- `.value: *` - Returns the data contained inside the unmutable wrapper.
+- `.isCollection(): boolean` - Returns true if the wrapped data is a collection. If it is it will have the methods listed below, depending on the type of wrapper.
+- `.isIndexed(): boolean` - Returns true if the wrapped data is an `Array` or `List`, or false otherwise.
+- `.isKeyed(): boolean` - Returns true if the wrapped data is an `Object` or `Map`, or false otherwise.
+- `.wrapperType(): string` - Returns the name of the unmutable wrapper type.
+
+Objects, Arrays, Lists and Maps will also have additional collection methods that mimic what Immutable.js' collections.
+
+Most methods return unmutable wrappers, except for those that ask questions about the contents of a collections (e.g. `has()`, `includes()` etc).
+
+```js
+Wrap(["1","2","3"]).get(0); // returns an unmutable wrapper containing "1"
+
+Wrap(["1","2","3"]).includes("1"); // returns true
+```
+
+Methods that have function parameters like `map()` and `reduce()` are passed their values in unmutable wrappers. If the original iterable is also received, this is also wrapped. Keys are not wrapped.
+
+```js
+Wrap([
+    {name: "tedd"},
+    {name: "todd"}
+])
+    .map((value, key, iter) => {
+        // value is an unmutable wrapper containing {name: "tedd"}, then {name: "todd"}
+        // key is the number 0, then 1
+        // iter is the original unmutable wrapper
+        return value.get("name");
+    });
+
+```
+
+It makes no difference if the value returned from a function parameter is wrapped or not, unmutable works with either.
+
+```js
+Wrap(["1","2","3"]).map(ii => ii); // returns Wrap(["1","2","3"])
+
+Wrap(["1","2","3"]).map(ii => ii.value); // also returns Wrap(["1","2","3"])
+```
+
+### Method feature set
+
+Objects, Arrays, Lists and Maps will also have the following methods, depending on whether `unmutable` or `unmutable-lite` is being used. New methods will be added over time.
+
+| `unmutable` Object / Map | `unmutable` Array / List | `unmutable-lite` Object / Map | `unmutable-lite` Array / List | Notes |
+| --- | --- | --- | --- | --- |
+| asImmutable | asImmutable | asImmutable | asImmutable ||
+| asMutable | asMutable | asMutable | asMutable ||
+| **butLast** ✔︎ | **butLast** ✔︎ | - | **butLast** ✔︎ ||
+| **clear** ✔︎ | **clear** ✔︎ | **clear** ✔︎ | **clear** ✔︎ ||
+| **concat** ✔︎ | **concat** ✔︎ | **concat** ✔︎ | **concat** ✔︎ ||
+| **count** ✔︎ | **count** ✔︎ | **count** ✔︎ | **count** ✔︎ | Returns plain number |
+| countBy | countBy | countBy | countBy ||
+| **delete** ✔︎ | **delete** ✔︎ | **delete** ✔︎ | **delete** ✔︎ ||
+| **deleteIn** ✔︎ | **deleteIn** ✔︎ | **deleteIn** ✔︎ | **deleteIn** ✔︎ ||
+| entries | entries | entries | entries ||
+| entrySeq | entrySeq | entrySeq | entrySeq ||
+| equals | equals | equals | equals ||
+| **every** ✔︎ | **every** ✔︎ | every | **every** ✔︎ | Returns plain boolean |
+| **filter** ✔︎ | **filter** ✔︎ | filter | filter ||
+| **filterNot** ✔︎ | **filterNot** ✔︎ | filterNot | filterNot ||
+| find | find | find | find ||
+| findEntry | findEntry | findEntry | findEntry ||
+| - | findIndex | - | findIndex ||
+| findKey | findKey | findKey | findKey ||
+| findLast | findLast | findLast | findLast ||
+| findLastEntry | findLastEntry | findLastEntry | findLastEntry ||
+| findLastIndex | findLastIndex | findLastIndex | findLastIndex ||
+| findLastKey | findLastKey | findLastKey | findLastKey ||
+| **first** ✔︎ | **first** ✔︎ | - | **first** ✔︎ ||
+| flatMap | flatMap | flatMap | flatMap ||
+| flatten | flatten | flatten | flatten ||
+| flip | - | flip | - ||
+| forEach | forEach | forEach | forEach ||
+|  - | fromEntrySeq | - | fromEntrySeq ||
+| **get** ✔︎ | **get** ✔︎ | **get** ✔︎ | **get** ✔︎ ||
+| **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ ||
+| groupBy | groupBy | groupBy | groupBy ||
+| **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | Returns plain boolean |
+| hashCode | hashCode | hashCode | hashCode ||
+| **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | Returns plain boolean |
+| **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | Returns plain boolean |
+| - | indexOf | - | indexOf ||
+| - | **insert** ✔︎ | - | insert ||
+| - | **interleave** ✔︎ | - | interleave ||
+| - | **interpose** ✔︎ | - | interpose ||
+| **isEmpty** ✔︎ | **isEmpty** ✔︎ | **isEmpty** ✔︎ | **isEmpty** ✔︎ ||
+| isSubset | isSubset | isSubset | isSubset ||
+| isSuperset | isSuperset | isSuperset | isSuperset ||
+| join | join | join | join ||
+| keyOf | keyOf | keyOf | keyOf ||
+| keys | keys | keys | keys ||
+| keySeq | keySeq | keySeq | keySeq ||
+| **last** ✔︎ | **last** ✔︎ | - | **last** ✔︎ ||
+| - | lastIndexOf | - | lastIndexOf ||
+| lastKeyOf | lastKeyOf | lastKeyOf | lastKeyOf ||
+| **map** ✔︎ | **map** ✔︎ | **map** ✔︎ | **map** ✔︎ ||
+| **mapEntries** ✔︎ | - | mapEntries | - ||
+| max | max | max | max ||
+| maxBy | maxBy | maxBy | maxBy ||
+| **merge** ✔︎ | **merge** ✔︎ | merge | merge ||
+| mergeDeep | mergeDeep | mergeDeep | mergeDeep ||
+| mergeDeepIn | mergeDeepIn | mergeDeepIn | mergeDeepIn ||
+| mergeDeepWith | mergeDeepWith | mergeDeepWith | mergeDeepWith ||
+| mergeIn | mergeIn | mergeIn | mergeIn ||
+| **mergeWith** ✔︎ | **mergeWith** ✔︎ | mergeWith | mergeWith ||
+| min | min | min | min ||
+| minBy | minBy | minBy | minBy ||
+| - | **pop** ✔︎ | - | **pop** ✔︎ ||
+| - | **push** ✔︎ | - | **push** ✔︎ ||
+| **reduce** ✔︎ | **reduce** ✔︎ | **reduce** ✔︎ | **reduce** ✔︎ ||
+| **reduceRight** ✔︎ | **reduceRight** ✔︎ | **reduceRight** ✔︎ | **reduceRight** ✔︎ ||
+| **rest** ✔︎ | **rest** ✔︎ | - | **rest** ✔︎ ||
+| **reverse** ✔︎ | **reverse** ✔︎ | - | **reverse** ✔︎ ||
+| **set** ✔︎ | **set** ✔︎ | **set** ✔︎ | **set** ✔︎ ||
+| **setIn** ✔︎ | **setIn** ✔︎ | **setIn** ✔︎ | **setIn** ✔︎ ||
+| - | setSize | - | setSize ||
+| - | **shift** ✔︎ | - | **shift** ✔︎ ||
+| **skip** ✔︎ | **skip** ✔︎ | - | **skip** ✔︎ ||
+| **skipLast** ✔︎ | **skipLast** ✔︎ | - | **skipLast** ✔︎ ||
+| **skipUntil** ✔︎ | **skipUntil** ✔︎ | - | skipUntil ||
+| **skipWhile** ✔︎ | **skipWhile** ✔︎ | - | skipWhile ||
+| **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ ||
+| **some** ✔︎ | **some** ✔︎ | some | **some** ✔︎ | Returns plain boolean |
+| **sort** ✔︎ | **sort** ✔︎ | sort | sort ||
+| **sortBy** ✔︎ | **sortBy** ✔︎ | sortBy | sortBy ||
+| - | splice | - | splice ||
+| **take** ✔︎ | **take** ✔︎ | - | **take** ✔︎ ||
+| **takeLast** ✔︎ | **takeLast** ✔︎ | - | **takeLast** ✔︎ ||
+| **takeUntil** ✔︎ | **takeUntil** ✔︎ | - | takeUntil ||
+| **takeWhile** ✔︎ | **takeWhile** ✔︎ | - | takeWhile ||
+| toArray | toArray | toArray | toArray ||
+| toIndexedSeq | toIndexedSeq | toIndexedSeq | toIndexedSeq ||
+| toJS | toJS | toJS | toJS ||
+| toJSON | toJSON | toJSON | toJSON ||
+| toKeyedSeq | toKeyedSeq | toKeyedSeq | toKeyedSeq ||
+| toList | toList | toList | toList ||
+| toMap | toMap | toMap | toMap ||
+| toObject | toObject | toObject | toObject ||
+| toOrderedMap | toOrderedMap | toOrderedMap | toOrderedMap ||
+| toOrderedSet | toOrderedSet | toOrderedSet | toOrderedSet ||
+| toSeq | toSeq | toSeq | toSeq ||
+| toSet | toSet | toSet | toSet ||
+| toSetSeq | toSetSeq | toSetSeq | toSetSeq ||
+| toStack | toStack | toStack | toStack ||
+| - | **unshift** ✔︎ | - | **unshift** ✔︎ ||
+| **update** ✔︎ | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ ||
+| **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ ||
+| values | values | values | values ||
+| valueSeq | valueSeq | valueSeq | valueSeq ||
+| withMutations | withMutations | withMutations | withMutations ||
+| - | zip | - | zip ||
+| - | zipWith | - | zipWith ||
+
+
+

--- a/packages/unmutable-extra/package.json
+++ b/packages/unmutable-extra/package.json
@@ -1,0 +1,33 @@
+{
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "name": "unmutable-extra",
+  "version": "0.11.1",
+  "description": "Immutable.js functions for collections that may or may not be Immutable (no dependency on Immutable.js).",
+  "license": "MIT",
+  "author": "Damien Clarke",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:blueflag/unmutable.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blueflag/unmutable/issues"
+  },
+  "private": false,
+  "scripts": {
+    "build": "rm -rf lib && babel src --out-dir lib",
+    "prepublish": "yarn run build && cp ../../README.md ./README.md",
+    "watch": "yarn run build -- -w"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "babel-core": "^6.23.0",
+    "babel-plugin-istanbul": "4.1.1",
+    "babel-preset-blueflag": "^0.3.0",
+    "babel-register": "^6.23.0",
+    "unmutable": "^0.11.1",
+    "unmutable-lite": "^0.11.1"
+  }
+}

--- a/packages/unmutable-extra/src/index.js
+++ b/packages/unmutable-extra/src/index.js
@@ -1,0 +1,2 @@
+// @flow
+export {default as pivot} from './pivot';

--- a/packages/unmutable-extra/src/pivot-test.js
+++ b/packages/unmutable-extra/src/pivot-test.js
@@ -1,0 +1,71 @@
+// @flow
+import test from 'ava';
+import {Wrap} from 'unmutable-lite';
+import {pivot} from './index';
+
+test('pivot should pivot arrays', (tt: *) => {
+    let data = Wrap([
+        [1,2,3],
+        [4,5,6]
+    ]);
+
+    let expectedData = [
+        [1,4],
+        [2,5],
+        [3,6]
+    ];
+
+    tt.deepEqual(expectedData, data.update(pivot()).value);
+});
+
+test('pivot should pivot objects', (tt: *) => {
+    let data = Wrap({
+        a: {
+            x: {
+                qqq: 111
+            },
+            y: {
+                qqq: 222
+            }
+        },
+        b: {
+            x: {
+                qqq: 333
+            }
+        },
+        c: {
+            y: {
+                qqq: 444
+            },
+            z: {
+                qqq: 555
+            }
+        }
+    });
+
+    let expectedData = {
+        x: {
+            a: {
+                qqq: 111
+            },
+            b: {
+                qqq: 333
+            }
+        },
+        y: {
+            a: {
+                qqq: 222
+            },
+            c: {
+                qqq: 444
+            }
+        },
+        z: {
+            c: {
+                qqq: 555
+            }
+        }
+    };
+
+    tt.deepEqual(expectedData, data.update(pivot()).value);
+});

--- a/packages/unmutable-extra/src/pivot.js
+++ b/packages/unmutable-extra/src/pivot.js
@@ -3,7 +3,8 @@
 export default function pivot(): Function {
     return (input: UnmutableWrapperType): UnmutableWrapperType => {
         let outerContainer = input.clear();
-        let innerContainer = input.first().clear();
+        let firstKey: number|string = input.keyArray().first().value;
+        let innerContainer = input.get(firstKey).clear();
         return input
             .reduce((pivoted: UnmutableWrapperType, outerItem: UnmutableWrapperType, outerKey: *): UnmutableWrapperType => {
                 return outerItem.reduce((pp: UnmutableWrapperType, value: UnmutableWrapperType, innerKey: *): UnmutableWrapperType => {

--- a/packages/unmutable-extra/src/pivot.js
+++ b/packages/unmutable-extra/src/pivot.js
@@ -1,0 +1,18 @@
+// @flow
+
+export default function pivot(): Function {
+    return (input: UnmutableWrapperType): UnmutableWrapperType => {
+        let outerContainer = input.clear();
+        let innerContainer = input.first().clear();
+        return input
+            .reduce((pivoted: UnmutableWrapperType, outerItem: UnmutableWrapperType, outerKey: *): UnmutableWrapperType => {
+                return outerItem.reduce((pp: UnmutableWrapperType, value: UnmutableWrapperType, innerKey: *): UnmutableWrapperType => {
+                    return pp.update(
+                        innerKey,
+                        (ii) => (ii.value ? ii : outerContainer).set(outerKey, value)
+                    );
+                }, pivoted);
+            }, innerContainer)
+            .value;
+    };
+}

--- a/packages/unmutable-lite/README.md
+++ b/packages/unmutable-lite/README.md
@@ -25,7 +25,7 @@ console.log(wrappedObject.getIn(['a', 'b']).value); // logs out "hi"
 
 ## Installation
 
-There are two packages you can choose from, `unmutable` or `unmutable-lite`.
+There are two main packages you can choose from, `unmutable` or `unmutable-lite`. There is also an optional package of extra functions called `unmutable-extra`.
 
 ### unmutable
 
@@ -59,6 +59,10 @@ or
 ```bash
 npm install unmutable-lite
 ```
+
+### unmutable-extra
+
+This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable-Extra).
 
 ## More examples
 
@@ -157,9 +161,9 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | entries | entries | entries | entries ||
 | entrySeq | entrySeq | entrySeq | entrySeq ||
 | equals | equals | equals | equals ||
-| **every** ✔︎ | **every** ✔︎ | every | **every** ✔︎ | Returns plain boolean |
-| **filter** ✔︎ | **filter** ✔︎ | filter | filter ||
-| **filterNot** ✔︎ | **filterNot** ✔︎ | filterNot | filterNot ||
+| **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | Returns plain boolean |
+| **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ ||
+| **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ ||
 | find | find | find | find ||
 | findEntry | findEntry | findEntry | findEntry ||
 | - | findIndex | - | findIndex ||
@@ -178,7 +182,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ ||
 | groupBy | groupBy | groupBy | groupBy ||
 | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | Returns plain boolean |
-| hashCode | hashCode | hashCode | hashCode ||
+| hashCode | hashCode | - | - ||
 | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | Returns plain boolean |
 | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | Returns plain boolean |
 | - | indexOf | - | indexOf ||
@@ -191,7 +195,8 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | join | join | join | join ||
 | keyOf | keyOf | keyOf | keyOf ||
 | keys | keys | keys | keys ||
-| keySeq | keySeq | keySeq | keySeq ||
+| keyList | keyList | keyList | keyList | Returns keys as an array, this doesn't exist in Immutable.js |
+| keySeq | keySeq | - | - ||
 | **last** ✔︎ | **last** ✔︎ | - | **last** ✔︎ ||
 | - | lastIndexOf | - | lastIndexOf ||
 | lastKeyOf | lastKeyOf | lastKeyOf | lastKeyOf ||
@@ -222,7 +227,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **skipUntil** ✔︎ | **skipUntil** ✔︎ | - | skipUntil ||
 | **skipWhile** ✔︎ | **skipWhile** ✔︎ | - | skipWhile ||
 | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ ||
-| **some** ✔︎ | **some** ✔︎ | some | **some** ✔︎ | Returns plain boolean |
+| **some** ✔︎ | **some** ✔︎ | **some** ✔︎  | **some** ✔︎ | Returns plain boolean |
 | **sort** ✔︎ | **sort** ✔︎ | sort | sort ||
 | **sortBy** ✔︎ | **sortBy** ✔︎ | sortBy | sortBy ||
 | - | splice | - | splice ||
@@ -231,19 +236,19 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **takeUntil** ✔︎ | **takeUntil** ✔︎ | - | takeUntil ||
 | **takeWhile** ✔︎ | **takeWhile** ✔︎ | - | takeWhile ||
 | toArray | toArray | toArray | toArray ||
-| toIndexedSeq | toIndexedSeq | toIndexedSeq | toIndexedSeq ||
+| toIndexedSeq | toIndexedSeq | - | - ||
 | toJS | toJS | toJS | toJS ||
 | toJSON | toJSON | toJSON | toJSON ||
-| toKeyedSeq | toKeyedSeq | toKeyedSeq | toKeyedSeq ||
-| toList | toList | toList | toList ||
-| toMap | toMap | toMap | toMap ||
+| toKeyedSeq | toKeyedSeq | - | - ||
+| toList | toList | - | - ||
+| toMap | toMap | - | - ||
 | toObject | toObject | toObject | toObject ||
-| toOrderedMap | toOrderedMap | toOrderedMap | toOrderedMap ||
-| toOrderedSet | toOrderedSet | toOrderedSet | toOrderedSet ||
-| toSeq | toSeq | toSeq | toSeq ||
-| toSet | toSet | toSet | toSet ||
-| toSetSeq | toSetSeq | toSetSeq | toSetSeq ||
-| toStack | toStack | toStack | toStack ||
+| toOrderedMap | toOrderedMap | - | - ||
+| toOrderedSet | toOrderedSet | - | - ||
+| toSeq | toSeq | - | - ||
+| toSet | toSet | - | - ||
+| toSetSeq | toSetSeq | - | - ||
+| toStack | toStack | - | - ||
 | - | **unshift** ✔︎ | - | **unshift** ✔︎ ||
 | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ ||
 | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ ||
@@ -253,5 +258,74 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | - | zip | - | zip ||
 | - | zipWith | - | zipWith ||
 
+## Unmutable Extra
 
+This package contains optional extra functions for unmutable that don't exist in Immutable.js.
 
+```bash
+yarn add unmutable-extra
+```
+
+or 
+
+```bash
+npm install unmutable-extra
+```
+
+Functions in this package use partially applied functions, which allow for easy chaining by using them inside of an `update()` method:
+
+```js
+return Wrap([1,2,3])
+    .update(pivot()) // using a pivot in a chain
+    .map(doOtherStuff)
+    .value
+```
+
+### API
+
+#### pivot
+`pivot() => (UnmutableWrapper)`
+
+Takes a collection that is 2 layers deep and flips the contents of each layer, in the same way that you might pivot a spreadsheet to turn rows into columns and vice versa. Works with any combination of Objects, Arrays, Maps and Lists.
+
+```js
+import {pivot} from 'unmutable-extra';
+
+return Wrap([
+    [1,2,3],
+    [4,5,6]
+])
+    .update(pivot())
+    .value;
+
+// Returns:
+// [
+//     [1,4],
+//     [2,5],
+//     [3,6]
+// ]
+
+return Wrap({
+    a: {
+        x: 1,
+        y: 2
+    },
+    b: {
+        x: 3
+    }
+})
+    .update(pivot())
+    .value;
+
+// Returns:
+// {
+//     x: {
+//         a: 1,
+//         b: 3
+//     },
+//     y: {
+//         a: 1
+//     }
+// }
+
+```

--- a/packages/unmutable-lite/src/UnmutableArrayWrapper.js
+++ b/packages/unmutable-lite/src/UnmutableArrayWrapper.js
@@ -21,6 +21,8 @@ export default class UnmutableArrayWrapper extends UnmutableWrapper {
             return clone;
         };
         _this.every = (condition: Function): * => item.every(condition);
+        _this.filter = (predicate: Function): * => item.filter(predicate);
+        _this.filterNot = (predicate: Function): * => item.filter((...args) => !predicate(...args));
         _this.first = (): * => item[0];
         _this.get = (key: *, notFoundValue: * = undefined): * => {
             if(!_this.has(key)) {

--- a/packages/unmutable-lite/src/UnmutableArrayWrapper.js
+++ b/packages/unmutable-lite/src/UnmutableArrayWrapper.js
@@ -59,6 +59,7 @@ export default class UnmutableArrayWrapper extends UnmutableWrapper {
             methodsFrom: this,
             wrap: Wrap,
             additionalMethods: [
+                "keyArray",
                 "deleteIn",
                 "hasIn",
                 "getIn",

--- a/packages/unmutable-lite/src/UnmutableListWrapper.js
+++ b/packages/unmutable-lite/src/UnmutableListWrapper.js
@@ -9,7 +9,10 @@ export default class UnmutableListWrapper extends UnmutableWrapper {
         AddMethods({
             self: this,
             methodsFrom: item,
-            wrap: Wrap
+            wrap: Wrap,
+            additionalMethods: [
+                "keyArray"
+            ]
         });
     }
 

--- a/packages/unmutable-lite/src/UnmutableMapWrapper.js
+++ b/packages/unmutable-lite/src/UnmutableMapWrapper.js
@@ -9,7 +9,10 @@ export default class UnmutableMapWrapper extends UnmutableWrapper {
         AddMethods({
             self: this,
             methodsFrom: item,
-            wrap: Wrap
+            wrap: Wrap,
+            additionalMethods: [
+                "keyArray"
+            ]
         });
     }
 

--- a/packages/unmutable-lite/src/UnmutableObjectWrapper.js
+++ b/packages/unmutable-lite/src/UnmutableObjectWrapper.js
@@ -50,6 +50,7 @@ export default class UnmutableObjectWrapper extends UnmutableWrapper {
             methodsFrom: this,
             wrap: Wrap,
             additionalMethods: [
+                "keyArray",
                 "deleteIn",
                 "hasIn",
                 "getIn",

--- a/packages/unmutable-lite/src/UnmutableObjectWrapper.js
+++ b/packages/unmutable-lite/src/UnmutableObjectWrapper.js
@@ -18,6 +18,21 @@ export default class UnmutableObjectWrapper extends UnmutableWrapper {
             delete clone[key];
             return clone;
         };
+        _this.every = (condition: Function): * => {
+            return Object.keys(item).every(ii => condition(item[ii], ii, item));
+        };
+        _this.filter = (predicate: Function): * => {
+            let result = {};
+            for(var key in item) {
+                if(predicate(item[key], key, item)) {
+                    result[key] = item[key];
+                }
+            }
+            return result;
+        };
+        _this.filterNot = (predicate: Function): * => {
+            return _this.filter((...args) => !predicate(...args));
+        };
         _this.get = (key: *, notFoundValue: * = undefined): * => _this.has(key) ? item[key] : notFoundValue;
         _this.has = (key: *): boolean => item.hasOwnProperty(key);
         _this.includes = (value: *): boolean => {
@@ -42,6 +57,9 @@ export default class UnmutableObjectWrapper extends UnmutableWrapper {
             return Object.keys(item).reverse().reduce((reduction, key) => mapper(reduction, item[key], key, item), initialReduction);
         };
         _this.set = (key: *, value: *): Object => ({...item, [key]: value});
+        _this.some = (condition: Function): * => {
+            return Object.keys(item).some(ii => condition(item[ii], ii, item));
+        };
         _this.update = update(_this, Wrap);
 
         // prepare methods

--- a/packages/unmutable-lite/src/index-test.js
+++ b/packages/unmutable-lite/src/index-test.js
@@ -13,6 +13,9 @@ var keyedTests: Array<string> = [
     "count",
     "delete",
     "deleteIn",
+    "every",
+    "filter",
+    "filterNot",
     "get",
     "getIn",
     "has",
@@ -24,6 +27,7 @@ var keyedTests: Array<string> = [
     "reduceRight",
     "set",
     "setIn",
+    "some",
     "update",
     "updateIn"
 ];
@@ -36,6 +40,8 @@ var indexedTests: Array<string> = [
     "delete",
     "deleteIn",
     "every",
+    "filter",
+    "filterNot",
     "first",
     "get",
     "getIn",

--- a/packages/unmutable/README.md
+++ b/packages/unmutable/README.md
@@ -25,7 +25,7 @@ console.log(wrappedObject.getIn(['a', 'b']).value); // logs out "hi"
 
 ## Installation
 
-There are two packages you can choose from, `unmutable` or `unmutable-lite`.
+There are two main packages you can choose from, `unmutable` or `unmutable-lite`. There is also an optional package of extra functions called `unmutable-extra`.
 
 ### unmutable
 
@@ -59,6 +59,10 @@ or
 ```bash
 npm install unmutable-lite
 ```
+
+### unmutable-extra
+
+This package contains optional extra functions for unmutable that don't exist in Immutable.js. See [Unmutable Extra](#Unmutable-Extra).
 
 ## More examples
 
@@ -157,9 +161,9 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | entries | entries | entries | entries ||
 | entrySeq | entrySeq | entrySeq | entrySeq ||
 | equals | equals | equals | equals ||
-| **every** ✔︎ | **every** ✔︎ | every | **every** ✔︎ | Returns plain boolean |
-| **filter** ✔︎ | **filter** ✔︎ | filter | filter ||
-| **filterNot** ✔︎ | **filterNot** ✔︎ | filterNot | filterNot ||
+| **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | **every** ✔︎ | Returns plain boolean |
+| **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ | **filter** ✔︎ ||
+| **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ | **filterNot** ✔︎ ||
 | find | find | find | find ||
 | findEntry | findEntry | findEntry | findEntry ||
 | - | findIndex | - | findIndex ||
@@ -178,7 +182,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ | **getIn** ✔︎ ||
 | groupBy | groupBy | groupBy | groupBy ||
 | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | **has** ✔︎ | Returns plain boolean |
-| hashCode | hashCode | hashCode | hashCode ||
+| hashCode | hashCode | - | - ||
 | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | **hasIn** ✔︎ | Returns plain boolean |
 | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | **includes** ✔︎ | Returns plain boolean |
 | - | indexOf | - | indexOf ||
@@ -191,7 +195,8 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | join | join | join | join ||
 | keyOf | keyOf | keyOf | keyOf ||
 | keys | keys | keys | keys ||
-| keySeq | keySeq | keySeq | keySeq ||
+| keyList | keyList | keyList | keyList | Returns keys as an array, this doesn't exist in Immutable.js |
+| keySeq | keySeq | - | - ||
 | **last** ✔︎ | **last** ✔︎ | - | **last** ✔︎ ||
 | - | lastIndexOf | - | lastIndexOf ||
 | lastKeyOf | lastKeyOf | lastKeyOf | lastKeyOf ||
@@ -222,7 +227,7 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **skipUntil** ✔︎ | **skipUntil** ✔︎ | - | skipUntil ||
 | **skipWhile** ✔︎ | **skipWhile** ✔︎ | - | skipWhile ||
 | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ | **slice** ✔︎ ||
-| **some** ✔︎ | **some** ✔︎ | some | **some** ✔︎ | Returns plain boolean |
+| **some** ✔︎ | **some** ✔︎ | **some** ✔︎  | **some** ✔︎ | Returns plain boolean |
 | **sort** ✔︎ | **sort** ✔︎ | sort | sort ||
 | **sortBy** ✔︎ | **sortBy** ✔︎ | sortBy | sortBy ||
 | - | splice | - | splice ||
@@ -231,19 +236,19 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | **takeUntil** ✔︎ | **takeUntil** ✔︎ | - | takeUntil ||
 | **takeWhile** ✔︎ | **takeWhile** ✔︎ | - | takeWhile ||
 | toArray | toArray | toArray | toArray ||
-| toIndexedSeq | toIndexedSeq | toIndexedSeq | toIndexedSeq ||
+| toIndexedSeq | toIndexedSeq | - | - ||
 | toJS | toJS | toJS | toJS ||
 | toJSON | toJSON | toJSON | toJSON ||
-| toKeyedSeq | toKeyedSeq | toKeyedSeq | toKeyedSeq ||
-| toList | toList | toList | toList ||
-| toMap | toMap | toMap | toMap ||
+| toKeyedSeq | toKeyedSeq | - | - ||
+| toList | toList | - | - ||
+| toMap | toMap | - | - ||
 | toObject | toObject | toObject | toObject ||
-| toOrderedMap | toOrderedMap | toOrderedMap | toOrderedMap ||
-| toOrderedSet | toOrderedSet | toOrderedSet | toOrderedSet ||
-| toSeq | toSeq | toSeq | toSeq ||
-| toSet | toSet | toSet | toSet ||
-| toSetSeq | toSetSeq | toSetSeq | toSetSeq ||
-| toStack | toStack | toStack | toStack ||
+| toOrderedMap | toOrderedMap | - | - ||
+| toOrderedSet | toOrderedSet | - | - ||
+| toSeq | toSeq | - | - ||
+| toSet | toSet | - | - ||
+| toSetSeq | toSetSeq | - | - ||
+| toStack | toStack | - | - ||
 | - | **unshift** ✔︎ | - | **unshift** ✔︎ ||
 | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ | **update** ✔︎ ||
 | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ | **updateIn** ✔︎ ||
@@ -253,5 +258,74 @@ Objects, Arrays, Lists and Maps will also have the following methods, depending 
 | - | zip | - | zip ||
 | - | zipWith | - | zipWith ||
 
+## Unmutable Extra
 
+This package contains optional extra functions for unmutable that don't exist in Immutable.js.
 
+```bash
+yarn add unmutable-extra
+```
+
+or 
+
+```bash
+npm install unmutable-extra
+```
+
+Functions in this package use partially applied functions, which allow for easy chaining by using them inside of an `update()` method:
+
+```js
+return Wrap([1,2,3])
+    .update(pivot()) // using a pivot in a chain
+    .map(doOtherStuff)
+    .value
+```
+
+### API
+
+#### pivot
+`pivot() => (UnmutableWrapper)`
+
+Takes a collection that is 2 layers deep and flips the contents of each layer, in the same way that you might pivot a spreadsheet to turn rows into columns and vice versa. Works with any combination of Objects, Arrays, Maps and Lists.
+
+```js
+import {pivot} from 'unmutable-extra';
+
+return Wrap([
+    [1,2,3],
+    [4,5,6]
+])
+    .update(pivot())
+    .value;
+
+// Returns:
+// [
+//     [1,4],
+//     [2,5],
+//     [3,6]
+// ]
+
+return Wrap({
+    a: {
+        x: 1,
+        y: 2
+    },
+    b: {
+        x: 3
+    }
+})
+    .update(pivot())
+    .value;
+
+// Returns:
+// {
+//     x: {
+//         a: 1,
+//         b: 3
+//     },
+//     y: {
+//         a: 1
+//     }
+// }
+
+```

--- a/packages/unmutable/src/UnmutableArrayWrapper.js
+++ b/packages/unmutable/src/UnmutableArrayWrapper.js
@@ -13,7 +13,10 @@ export default class UnmutableArrayWrapper extends UnmutableWrapper {
             self: this,
             methodsFrom: list,
             wrap: Wrap,
-            fromWrapperData: ii => ii.toArray()
+            fromWrapperData: ii => ii.toArray(),
+            additionalMethods: [
+                "keyArray"
+            ]
         });
     }
 

--- a/packages/unmutable/src/UnmutableListWrapper.js
+++ b/packages/unmutable/src/UnmutableListWrapper.js
@@ -11,7 +11,10 @@ export default class UnmutableListWrapper extends UnmutableWrapper {
             self: this,
             methodsFrom: item,
             wrap: Wrap,
-            toWrapperData: Map
+            toWrapperData: Map,
+            additionalMethods: [
+                "keyArray"
+            ]
         });
     }
 

--- a/packages/unmutable/src/UnmutableMapWrapper.js
+++ b/packages/unmutable/src/UnmutableMapWrapper.js
@@ -11,7 +11,10 @@ export default class UnmutableMapWrapper extends UnmutableWrapper {
             self: this,
             methodsFrom: item,
             wrap: Wrap,
-            toWrapperData: Map
+            toWrapperData: Map,
+            additionalMethods: [
+                "keyArray"
+            ]
         });
     }
 

--- a/packages/unmutable/src/UnmutableObjectWrapper.js
+++ b/packages/unmutable/src/UnmutableObjectWrapper.js
@@ -12,7 +12,10 @@ export default class UnmutableObjectWrapper extends UnmutableWrapper {
             self: this,
             methodsFrom: map,
             wrap: Wrap,
-            fromWrapperData: ii => ii.toObject()
+            fromWrapperData: ii => ii.toObject(),
+            additionalMethods: [
+                "keyArray"
+            ]
         });
     }
 


### PR DESCRIPTION
## Additions

- Added `unmutable-extra` with `pivot` function (`uniqueBy` and `averageBy` would be good in future)
- Added `keyArray()` to all collections, which works like `keySeq` but returns an array of keys.
- Added `filter()` and `filterNot()` to `unmutable-lite` arrays
- Added `every()`, `filter()`, `filterNot()` and `some()` to `unmutable-lite` objects.

## Fixes

- `reduce()` no longer unwraps returned data item.
- `set()` and `setIn()` now have their values shallowly unwrapped before setting them, to try and prevent accidental nesting of unmutable objects. The same treatment should also go for all methods that accept new values as parameters like `unshift()` or `insert()`.