### PR TITLE
Feature/do if

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -82,7 +82,6 @@ zipWith *
 ### To be implemented
 
 ```
-countBy
 flatMap
 flatten
 flip
@@ -124,6 +123,7 @@ The following functions will not be implemented in Unmutable.js
 [Symbol.iterator]()
 asMutable
 asImmutable
+countBy
 entrySeq
 fromEntrySeq
 hashCode
@@ -146,6 +146,11 @@ withMutations
 
 
 ### Extra functions
+
+#### pa/doIf
+`doIf(predicate: Function, ifTrue: Function, ifFalse: Function = ii => ii) => (value) => newValue` - Returns an evaluator that passes the value to the predicate function. If the predicate returns true, the value is then passed through the `ifTrue` function and the result is returned. If the predicate returns false then the value is simply returned unchanged.
+
+If the third argument `ifFalse` is provided, then the value will be passed through `ifFalse` when the predicate returns false.
 
 #### pa/entriesReverse
 `entriesReverse() => (value) => Iterator` - Returns an evaluator that works just like `entries()`, but iterates in the reverse order.

--- a/src/__test__/doIf-test.js
+++ b/src/__test__/doIf-test.js
@@ -1,0 +1,57 @@
+// @flow
+import doIf from '../doIf';
+import test from 'ava';
+
+test(`doIf() should do the thing if true`, (tt: *) => {
+    tt.deepEqual(
+        [2,4,6],
+        doIf(
+            () => true,
+            value => value.map(ii => ii * 2)
+        )([1,2,3])
+    );
+});
+
+test(`doIf() should not do the thing if false`, (tt: *) => {
+    tt.deepEqual(
+        [1,2,3],
+        doIf(
+            () => false,
+            value => value.map(ii => ii * 2)
+        )([1,2,3])
+    );
+});
+
+test(`doIf() should be passed the value`, (tt: *) => {
+    let theValue = [1,2,3];
+
+    doIf(
+        (vv: *): * => {
+            tt.is(theValue, vv);
+            return false;
+        },
+        value => value
+    )(theValue);
+});
+
+test(`doIf() should do the thing if true with 3 args`, (tt: *) => {
+    tt.deepEqual(
+        [2,4,6],
+        doIf(
+            () => true,
+            value => value.map(ii => ii * 2),
+            value => value.map(ii => ii * 3)
+        )([1,2,3])
+    );
+});
+
+test(`doIf() should do the other thing if false with 3 args`, (tt: *) => {
+    tt.deepEqual(
+        [3,6,9],
+        doIf(
+            () => false,
+            value => value.map(ii => ii * 2),
+            value => value.map(ii => ii * 3)
+        )([1,2,3])
+    );
+});

--- a/src/__test__/findIndex-test.js
+++ b/src/__test__/findIndex-test.js
@@ -1,0 +1,30 @@
+// @flow
+import findIndex from '../findIndex';
+import compare from '../internal/compare';
+import compareIteratee from '../internal/compareIteratee';
+
+compare({
+    name: `findIndex() on array should findIndex thing`,
+    item: [1,2,3,4],
+    fn: findIndex(value => value > 2)
+});
+
+compare({
+    name: `findIndex() on array should not findIndex thing that doesnt exist`,
+    item: [1,2,3,4],
+    fn: findIndex(value => value > 6)
+});
+
+compareIteratee({
+    name: `findIndex() on array should pass correct arguments to iteratee`,
+    item: [1,2,3,4],
+    fn: (checkArgs) => findIndex((value: *, key: * /*, iter: * */): boolean => {
+        checkArgs({value, key /*, iter */});
+        // TODO: INVESTIGATE STRANGE BEHAVIOUR
+        // Immutable.js does not pass the original iterable as iter to the predicate of List.findIndex()
+        // instead it passes a KeyedCollection
+        // omit from test for now
+        return true;
+    }),
+    argsToJS: ['iter']
+});

--- a/src/__test__/merge-test.js
+++ b/src/__test__/merge-test.js
@@ -8,3 +8,10 @@ compare({
     fn: merge({b:6,c:3}),
     toJS: true
 });
+
+compare({
+    name: `merge() array should merge an array`,
+    item: [1,2,3],
+    fn: merge([4,5,6]),
+    toJS: true
+});

--- a/src/doIf.js
+++ b/src/doIf.js
@@ -1,0 +1,8 @@
+// @flow
+import prep from './internal/prep';
+
+export default prep({
+    all: (predicate: Function, ifTrue: Function, ifFalse: Function = ii => ii) => (item: *): * => {
+        return (predicate(item) ? ifTrue : ifFalse)(item);
+    }
+});

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -1,0 +1,16 @@
+// @flow
+import prep from './internal/prep';
+import entries from './entries';
+
+export default prep({
+    immutable: 'findIndex',
+    all: (predicate: Function) => (item: Object): * => {
+        let iterator = entries()(item);
+        for(let [key, value] of iterator) {
+            if(predicate(value, key, item)) {
+                return key;
+            }
+        }
+        return -1;
+    }
+});

--- a/src/merge.js
+++ b/src/merge.js
@@ -3,5 +3,6 @@ import prep from './internal/prep';
 
 export default prep({
     immutable: 'merge',
-    object: (newItem: Object) => (item): Object => ({...item, ...newItem})
+    object: (newItem: Object) => (item): Object => ({...item, ...newItem}),
+    array: (newItem: Array<*>) => (item: Array<*>): Array<*> => [...item, ...newItem]
 });


### PR DESCRIPTION
- Add `doIf`
- Add indexed abilities on `merge()`. `List.merge()` is strangely absent from Immutable.js docs.
- Add `findIndex()` - previously thought this was added but it wasnt
- `countBy` returns a `Seq` in Immutable.js and therefore cannot be added to unmutable. A similar function with a different name could be quite useful.
