### PR TITLE
Stop .reverse & .sort from mutating the array

### DIFF
--- a/src/reverse.js
+++ b/src/reverse.js
@@ -4,5 +4,5 @@ import prep from './internal/prep';
 export default prep({
     name: 'reverse',
     immutable: 'reverse',
-    array: () => (item: Array<*>): Array<*> => item.reverse()
+    array: () => (item: Array<*>): Array<*> => [...item].reverse()
 });

--- a/src/sort.js
+++ b/src/sort.js
@@ -5,6 +5,6 @@ export default prep({
     name: 'sort',
     immutable: 'sort',
     array: (comparator: Function) => (value: Array<*>): Array<*> => {
-        return value.sort(comparator);
+        return [...value].sort(comparator);
     }
 });


### PR DESCRIPTION
Turns out `reverse` and `sort` mutate arrays.