### PR TITLE
BREAKING CHANGE: class instances and functions as values are now treated like objects

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -6,9 +6,15 @@ Functions that normally work on `List`s will work on `List` and arrays, function
 
 It's a work in progress so not all functions have been implemented yet.
 
+## Class instances and functions-as-objects
+
+Experimental support for class instances and functions being used as objects has been added.
+Currently these should work with methods that don't make changes to the data structure (`get`, `getIn`, `find` etc.)
+There are plans for a standard API that unmutable can use with methods that make data changes.
+
 ## Functions
 
-All `pa` functions return an evaluator. An evaluator is a function that accepts a value and returns a result.
+All functions exported from `unmutable/lib/XXX` return an evaluator. An evaluator is a function that accepts a value and returns a result.
 
 - * The asterisk indicates functions which only work with `List`s and arrays.
 - ^ The carat indicates functions that are confirmed to work with `Record`s.

--- a/src/__test__/get-test.js
+++ b/src/__test__/get-test.js
@@ -59,3 +59,17 @@ test('get() on record should work', (t: *) => {
     const TestRecord = Record({foo: 'bar'});
     t.is(get('foo')(new TestRecord()), 'bar');
 });
+
+test('get() on class instance should work', (t: *) => {
+    class A {
+        foo = 'bar';
+    }
+    t.is(get('foo')(new A()), 'bar');
+});
+
+test('get() on function should work', (t: *) => {
+    let fn = () => {};
+    fn.foo = 'bar';
+    t.is(get('foo')(fn), 'bar');
+});
+

--- a/src/internal/__test__/predicates-test.js
+++ b/src/internal/__test__/predicates-test.js
@@ -40,7 +40,9 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -71,7 +73,9 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -102,7 +106,9 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -133,7 +139,9 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: false,
-        stack3: false
+        stack3: false,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -164,7 +172,9 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -195,7 +205,9 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -226,7 +238,9 @@ testTypes({
         set3: false,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -257,7 +271,9 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: false,
-        stack3: false
+        stack3: false,
+        function: false,
+        classInstance: false
     }
 });
 
@@ -288,6 +304,8 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });

--- a/src/internal/__test__/prep-test.js
+++ b/src/internal/__test__/prep-test.js
@@ -78,6 +78,45 @@ test(`prep should handle Objects`, (tt: *) => {
     tt.is(tt.throws(() => useNone('a')(myObject), Error).message, `noooooo() cannot be called on [object Object]`);
 });
 
+test(`prep should handle class instances`, (tt: *) => {
+    class A {
+        a = 1;
+        b = 2;
+        c = 3;
+    }
+    let myClassInstance = new A();
+    let object = (key) => (item) => `${key}-${item.a}-object`;
+    let all = (key) => (item) => `${key}-${item.a}-all`;
+
+    let useObject = prep({name: "get", immutable: "get", object, all});
+    let useKeyed = prep({name: "get", immutable: "get", all});
+    let useAll = prep({name: "get", immutable: "get", all});
+    let useNone = prep({name: "noooooo", immutable: "noooooo"});
+
+    tt.is("a-1-object", useObject('a')(myClassInstance));
+    tt.is("a-1-all", useAll('a')(myClassInstance));
+    tt.is(tt.throws(() => useNone('a')(myClassInstance), Error).message, `noooooo() cannot be called on [object Object]`);
+});
+
+test(`prep should handle functions`, (tt: *) => {
+    let myFunction = () => {};
+    myFunction.a = 1;
+    myFunction.b = 2;
+    myFunction.c = 3;
+
+    let object = (key) => (item) => `${key}-${item.a}-object`;
+    let all = (key) => (item) => `${key}-${item.a}-all`;
+
+    let useObject = prep({name: "get", immutable: "get", object, all});
+    let useKeyed = prep({name: "get", immutable: "get", all});
+    let useAll = prep({name: "get", immutable: "get", all});
+    let useNone = prep({name: "noooooo", immutable: "noooooo"});
+
+    tt.is("a-1-object", useObject('a')(myFunction));
+    tt.is("a-1-all", useAll('a')(myFunction));
+    tt.is(tt.throws(() => useNone('a')(myFunction), Error).message, `noooooo() cannot be called on function myFunction() {}`);
+});
+
 
 test(`prep should not handle strings as values`, (tt: *) => {
     let useNone = prep({name: "find", array: () => {}});

--- a/src/internal/__test__/testTypes-testutil.js
+++ b/src/internal/__test__/testTypes-testutil.js
@@ -35,7 +35,10 @@ class ABRecordExtended extends ABRecord {}
 const ABRecord3 = Record3({a: 1, b: 2});
 class ABRecordExtended3 extends ABRecord3 {}
 
+class A {}
+
 export default ({name, fn, expectedResult}: TestTypesConfig) => {
+
     const types = {
         undefined: undefined,
         null: null,
@@ -60,7 +63,9 @@ export default ({name, fn, expectedResult}: TestTypesConfig) => {
         set3: Set3(),
         orderedSet3: OrderedSet3(),
         seq3: Seq3(),
-        stack3: Stack3()
+        stack3: Stack3(),
+        function: () => {},
+        classInstance: new A()
     };
 
     const result = Object.keys(types).reduce((obj, key) => ({

--- a/src/internal/prep.js
+++ b/src/internal/prep.js
@@ -4,6 +4,8 @@ import {
     isRecord
 } from '../internal/predicates';
 
+import isObject from '../util/isObject';
+
 const error = (name: string, value: *) => {
     throw new Error(`${name}() cannot be called on ${value}`);
 };
@@ -50,7 +52,7 @@ const PREP_TYPES: Array<PrepType> = [
     },
     {
         type: "object",
-        isType: (value: *): boolean => typeof value === "object",
+        isType: isObject,
         fn: (name: string, object: Function) => object
 
     },

--- a/src/util/__test__/isAssociative-test.js
+++ b/src/util/__test__/isAssociative-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: true,
+        classInstance: true
     }
 });

--- a/src/util/__test__/isCollection-test.js
+++ b/src/util/__test__/isCollection-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: true,
+        classInstance: true
     }
 });

--- a/src/util/__test__/isImmutable-test.js
+++ b/src/util/__test__/isImmutable-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });

--- a/src/util/__test__/isIndexed-test.js
+++ b/src/util/__test__/isIndexed-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });

--- a/src/util/__test__/isKeyed-test.js
+++ b/src/util/__test__/isKeyed-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: false,
-        stack3: false
+        stack3: false,
+        function: true,
+        classInstance: true
     }
 });

--- a/src/util/__test__/isOrdered-test.js
+++ b/src/util/__test__/isOrdered-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: false,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: false,
+        classInstance: false
     }
 });

--- a/src/util/__test__/isPlainObject-test.js
+++ b/src/util/__test__/isPlainObject-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: false,
-        stack3: false
+        stack3: false,
+        function: false,
+        classInstance: false
     }
 });

--- a/src/util/__test__/isRecord-test.js
+++ b/src/util/__test__/isRecord-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: false,
         orderedSet3: false,
         seq3: false,
-        stack3: false
+        stack3: false,
+        function: false,
+        classInstance: false
     }
 });

--- a/src/util/__test__/isValueObject-test.js
+++ b/src/util/__test__/isValueObject-test.js
@@ -29,6 +29,8 @@ testTypes({
         set3: true,
         orderedSet3: true,
         seq3: true,
-        stack3: true
+        stack3: true,
+        function: true,
+        classInstance: true
     }
 });

--- a/src/util/isAssociative.js
+++ b/src/util/isAssociative.js
@@ -1,5 +1,7 @@
 // @flow
-import isPlainObject from 'is-plain-object';
-import {isAssociative} from '../internal/predicates';
+import {isAssociative, isImmutable} from '../internal/predicates';
+import isObject from './isObject';
 
-export default (thing: *): boolean => isAssociative(thing) || Array.isArray(thing) || isPlainObject(thing);
+export default (thing: *): boolean => isImmutable(thing)
+    ? isAssociative(thing)
+    : isObject(thing);

--- a/src/util/isCollection.js
+++ b/src/util/isCollection.js
@@ -1,5 +1,7 @@
 // @flow
-import isPlainObject from 'is-plain-object';
-import {isCollection} from '../internal/predicates';
+import {isCollection, isImmutable} from '../internal/predicates';
+import isObject from './isObject';
 
-export default (thing: *): boolean => isCollection(thing) || Array.isArray(thing) || isPlainObject(thing);
+export default (thing: *): boolean => isImmutable(thing)
+    ? isCollection(thing)
+    : isObject(thing);

--- a/src/util/isKeyed.js
+++ b/src/util/isKeyed.js
@@ -1,5 +1,7 @@
 // @flow
-import isPlainObject from 'is-plain-object';
-import {isKeyed} from '../internal/predicates';
+import isObject from './isObject';
+import {isImmutable, isKeyed} from '../internal/predicates';
 
-export default (thing: *): boolean => isKeyed(thing) || isPlainObject(thing);
+export default (thing: *): boolean => isImmutable(thing)
+    ? isKeyed(thing)
+    : !Array.isArray(thing) && isObject(thing);

--- a/src/util/isObject.js
+++ b/src/util/isObject.js
@@ -1,0 +1,2 @@
+// @flow
+export default (thing: *): boolean => thing === Object(thing);

--- a/src/util/isValueObject.js
+++ b/src/util/isValueObject.js
@@ -1,5 +1,7 @@
 // @flow
-import isPlainObject from 'is-plain-object';
-import {isCollection, isValueObject} from '../internal/predicates';
+import isObject from './isObject';
+export default isObject;
 
-export default (thing: *): boolean => isCollection(thing) || isValueObject(thing) || Array.isArray(thing) || isPlainObject(thing);
+// this file exists to align with immutable.js definition of valueObject
+// isValueObject ends up being the same as isObject()
+// this file is retained for API completeness


### PR DESCRIPTION
Experimental support for class instances and functions being used as objects has been added. Currently these should work with methods that don't make changes to the data structure (`get`, `getIn`, `find` etc.) There are plans for a standard API that `unmutable` can use with methods that make data changes.

Behaviour change is exemplified by these two tests:

```js
test('get() on class instance should work', (t: *) => {
    class A {
        foo = 'bar';
    }
    t.is(get('foo')(new A()), 'bar');
});

test('get() on function should work', (t: *) => {
    let fn = () => {};
    fn.foo = 'bar';
    t.is(get('foo')(fn), 'bar');
});
```

Also added `unmutable/lib/util/isObject`, which returns true for all non-primitives including arrays.