### PR TITLE
Feature/range

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -289,5 +289,24 @@ Utils include functions that make Unmutable.js useable and useful, as well as pl
  toLowerCase()("HELLO"); // "hello"
  ```
 
+#### util/overload
+`overload(overloads: Object) => Function` - Simulates function overloading. It accepts an object with number strings as keys, and functions to call as values. It returns the overloaded function. When the overloaded function is called with `x` arguments, the function with the key of `x` on the passed-in object will be called. If the overloaded function is called with a number of arguments not specified in the passed-in object, an error is thrown.
+
+```
+import overload from 'unmutable/lib/util/overload';
+let fn = overload({
+    ["2"]: (a, b) => `${a} ${b}`,
+    ["3"]: (c, a, b) => `(${a} ${b}) ${c}`,
+});
+
+fn("!", "?"); // returns "! ?"
+fn("!", "?", "*"); // returns "(! ?) *"
+fun("!") // throws an error
+
+```
+
+#### util/range
+`range([start=0], end, [step=1])` - Helper function to generate an array of sequential numbers. Simply a re-export of [lodash.range](https://lodash.com/docs/4.17.10#range)
+
 #### util/recordAsObject
  `recordAsObject(updater: Function, value: *, returnRecord: boolean) => *` - Helper function that allows you to update an Immutable.js `Record`. The updater receives an object version of the `Record`. If `returnRecord = true`, the result of the updater will be passed back into the `Record`'s constructor before being returned. If `returnRecord = false`, the data returned from `updater` will be returned directly from `recordAsObject` without change.

--- a/DOCS.md
+++ b/DOCS.md
@@ -296,7 +296,7 @@ Utils include functions that make Unmutable.js useable and useful, as well as pl
 import overload from 'unmutable/lib/util/overload';
 let fn = overload({
     ["2"]: (a, b) => `${a} ${b}`,
-    ["3"]: (c, a, b) => `(${a} ${b}) ${c}`,
+    ["3"]: (a, b, c) => `(${a} ${b}) ${c}`,
 });
 
 fn("!", "?"); // returns "! ?"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "fast-deep-equal": "^1.0.0",
-    "is-plain-object": "^2.0.4"
+    "is-plain-object": "^2.0.4",
+    "lodash.range": "^3.2.0"
   }
 }

--- a/src/update.js
+++ b/src/update.js
@@ -4,13 +4,16 @@ import get from './get';
 import overload from './util/overload';
 import set from './set';
 
+let update = (key: string, updater: Function, notSetValue: * = undefined) => (value): * => {
+    return set(key, updater(get(key, notSetValue)(value)))(value);
+};
+
 export default prep({
     name: 'update',
     immutable: 'update',
     all: overload({
-        ["1"]: () => (updater: Function) => (value) => updater(value),
-        ["2"]: (fn) => (key: string, updater: Function) => fn(key, updater),
-        ["3"]: (fn) => (key: string, notSetValue: *, updater: Function) => fn(key, updater, notSetValue)
-    },
-    (key: string, updater: Function, notSetValue: * = undefined) => (value) => set(key, updater(get(key, notSetValue)(value)))(value))
+        ["1"]: (updater: Function) => (value) => updater(value),
+        ["2"]: (key: string, updater: Function) => update(key, updater),
+        ["3"]: (key: string, notSetValue: *, updater: Function) => update(key, updater, notSetValue)
+    })
 });

--- a/src/updateIn.js
+++ b/src/updateIn.js
@@ -6,16 +6,17 @@ import overload from './util/overload';
 
 // we're not using Immutable.js updateIn because it can't cope with mixed types in the keyPath
 
+let updateIn = (keyPath: string[], updater: Function, notSetValue: * = undefined) => (value: *): * => {
+    let updated: * = updater(getIn(keyPath, notSetValue)(value));
+    return updated === notSetValue
+        ? value
+        : setIn(keyPath, updated)(value);
+};
+
 export default prep({
     name: 'updateIn',
     all: overload({
-        ["2"]: (fn) => (keyPath: string[], updater: Function) => fn(keyPath, updater),
-        ["3"]: (fn) => (keyPath: string[], notSetValue: *, updater: Function) => fn(keyPath, updater, notSetValue)
-    },
-    (keyPath: string[], updater: Function, notSetValue: * = undefined) => (value: *): * => {
-        let updated: * = updater(getIn(keyPath, notSetValue)(value));
-        return updated === notSetValue
-            ? value
-            : setIn(keyPath, updated)(value);
+        ["2"]: (keyPath: string[], updater: Function) => updateIn(keyPath, updater),
+        ["3"]: (keyPath: string[], notSetValue: *, updater: Function) => updateIn(keyPath, updater, notSetValue)
     })
 });

--- a/src/util/__test__/overload-test.js
+++ b/src/util/__test__/overload-test.js
@@ -4,8 +4,8 @@ import {fromJS} from 'immutable';
 
 test(`overload() should call correct sub functions`, () => {
     let myOverloadyFunction = overload({
-        ["2"]: () => (a, b) => `${a} ${b}`,
-        ["3"]: () => (c, a, b) => `(${a} ${b}) ${c}`,
+        ["2"]: (a, b) => `${a} ${b}`,
+        ["3"]: (c, a, b) => `(${a} ${b}) ${c}`,
     });
 
     expect("A B").toBe(myOverloadyFunction("A", "B"));
@@ -14,20 +14,9 @@ test(`overload() should call correct sub functions`, () => {
 
 test(`overload() should throw if called with an incorrect number of arguments`, () => {
     let myOverloadyFunction = overload({
-        ["2"]: () => (a, b) => `${a} ${b}`,
-        ["3"]: () => (c, a, b) => `(${a} ${b}) ${c}`,
+        ["2"]: (a, b) => `${a} ${b}`,
+        ["3"]: (c, a, b) => `(${a} ${b}) ${c}`,
     });
 
     expect(() => myOverloadyFunction("A")).toThrowError(`Function must be given this many arguments: 2, 3`);
-});
-
-test(`overload() should pass innerArgs object to each overloaded myOverloadyFunction`, () => {
-    let myOverloadyFunction = overload({
-        ["2"]: (fn) => (a, c) => fn(a,"-",c),
-        ["3"]: (fn) => (a, b, c) => fn(a,b,c)
-    },
-    (a,b,c) => `(${a} ${b}) ${c}`);
-
-    expect("(A -) C").toBe(myOverloadyFunction("A", "C"));
-    expect("(A B) C").toBe(myOverloadyFunction("A", "B", "C"));
 });

--- a/src/util/__test__/range-test.js
+++ b/src/util/__test__/range-test.js
@@ -1,0 +1,20 @@
+// @flow
+
+import range from '../range';
+
+test('range makes a range with from zero', () => {
+    expect(range(4)).toEqual([0, 1, 2, 3]);
+});
+
+test('range makes a range with from zero downward', () => {
+    expect(range(-4)).toEqual([0, -1, -2, -3]);
+});
+
+test('range makes a range with a start and end', () => {
+    expect(range(1, 5)).toEqual([1, 2, 3, 4]);
+});
+
+test('range makes a range with a start, end and step', () => {
+    expect(range(0, 20, 5)).toEqual([0, 5, 10, 15]);
+});
+

--- a/src/util/overload.js
+++ b/src/util/overload.js
@@ -1,9 +1,9 @@
 // @flow
 
-export default (overloads: Object, ...innerArgs: *) => (...args: Array<*>): * => {
+export default (overloads: Object) => (...args: Array<*>): * => {
     let fn = overloads[`${args.length}`];
     if(!fn) {
         throw new Error(`Function must be given this many arguments: ${Object.keys(overloads).join(", ")}`);
     }
-    return fn(...innerArgs)(...args);
+    return fn(...args);
 };

--- a/src/util/range.js
+++ b/src/util/range.js
@@ -1,0 +1,4 @@
+// @flow
+
+import range from 'lodash.range';
+export default range;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4574,6 +4574,10 @@ lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
- Add `util/range`, a re-export of [lodash.range](https://lodash.com/docs/4.17.10#range)
- **BREAKING CHANGE** `util/overload` no longer has a concept of `innerArgs`. It now only accepts a single argument, and each function on the `overloads` object needs to be `(...args) => result`, rather than `(...innerArgs) => (...args) => result`