### PR TITLE
Feature/a bunch

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -44,10 +44,14 @@ findLastIndex
 findLastKey
 first
 flatMap
+forEach
 get ^
 getIn ^
+groupBy - object and arrays cannot be grouped on deeply equal keys because plain objects cannot have objects as keys
 has ^
+hashCode - non-Immutable.js values are JSON stringified
 hasIn ^
+includes
 insert *
 interpose *
 isEmpty ^
@@ -93,9 +97,6 @@ zipWith *
 ```
 flatten
 flip
-forEach
-groupBy
-includes
 indexOf *
 interleave *
 isSubset
@@ -132,7 +133,6 @@ asImmutable
 countBy
 entrySeq
 fromEntrySeq
-hashCode
 keySeq
 toList
 toMap
@@ -185,6 +185,9 @@ If the third argument `ifFalse` is provided, then the value will be passed throu
 #### log
 `log(message: string = "", type: string = "log") => (value) => value` - Returns an evaluator that passes the value through unchanged, but also calls `console[type](message, value)`. Useful for debugging.
 
+#### notEquals
+`notEquals(other) => (value) => boolean` - Returns an evaluator that returns `true` if `value` and `other` are not deeply equal, or `false` otherwise.
+
 #### omit
 `omit(keys: string[]|number[]) => (value) => newValue` - For `Map` and object: Returns an evaluator that filters out all keys listed in `keys`.
 
@@ -223,6 +226,12 @@ If the third argument `ifFalse` is provided, then the value will be passed throu
 
 #### updateInto
 `updateInto(key: string|number, updater: Function) => (value) => *` - Returns an evaluator that passes `value` to `updater`, and will set `value.key` to the result of the `updater`. In practise it works like `update(key, updater) => (value)` but where `updater` receives `value` instead of `value.key`.
+
+#### unique
+`unique() => (value) => *` - Returns an evaluator that filters `value` so that any element with a duplicate value is filtered out. If a non-primitive is returned from `getter`, it is compared deeply.
+
+#### uniqueBy
+`uniqueBy(getter: Function) => (value) => *` - Returns an evaluator that filters `value` according to the result of `getter`, so that any element with a duplicate result of `getter` is filtered out. If a non-primitive is returned from `getter`, it is compared deeply.
 
 #### valueArray
 `valueArray() => (value) => Array` - Returns an evaluator that returns an array of values on the value. Immutable.js has no function that does this, they have `values()` which returns an iterator, and `valueSeq()` which returns an Immutable.js `Seq`.

--- a/src/__test__/equals-test.js
+++ b/src/__test__/equals-test.js
@@ -1,4 +1,5 @@
 // @flow
+import {fromJS} from 'immutable';
 import equals from '../equals';
 
 test(`equals() should do what it says on the tin when things are the same`, () => {
@@ -6,4 +7,11 @@ test(`equals() should do what it says on the tin when things are the same`, () =
 });
 test(`equals() should do what it says on the tin when things are not the same`, () => {
     expect(equals({a:1,b:[2,3]})({a:1,b:[2,4]})).toBe(false);
+});
+
+test(`equals() should do what it says on the tin when immutable things are the same`, () => {
+    expect(equals(fromJS({a:1,b:[2,3]}))(fromJS({a:1,b:[2,3]}))).toBe(true);
+});
+test(`equals() should do what it says on the tin when immutable things are not the same`, () => {
+    expect(equals(fromJS({a:1,b:[2,3]}))(fromJS({a:1,b:[2,4]}))).toBe(false);
 });

--- a/src/__test__/forEach-test.js
+++ b/src/__test__/forEach-test.js
@@ -1,0 +1,38 @@
+// @flow
+import forEach from '../forEach';
+import compare from '../internal/__test__/compare-testutil';
+import compareIteratee from '../internal/__test__/compareIteratee-testutil';
+
+compare({
+    name: `forEach() on object should work`,
+    item: {a:1, b:2, c:3, d:4},
+    fn: forEach(() => {})
+});
+
+compare({
+    name: `forEach() on object should bail if false is returned`,
+    item: {a:1, b:2, c:3, d:4},
+    fn: forEach((value) => value < 3)
+});
+
+compare({
+    name: `forEach() on array should work`,
+    item: [1,2,3,4],
+    fn: forEach(() => {})
+});
+
+compare({
+    name: `forEach() on array should bail if false is returned`,
+    item: [1,2,3,4],
+    fn: forEach((value) => value < 3)
+});
+
+compareIteratee({
+    name: `forEach() on array should pass correct arguments to iteratee`,
+    item: [1,2,3,4],
+    fn: (checkArgs) => forEach((value: *, key: *, iter: *): * => {
+        checkArgs({value, key, iter});
+    }),
+    argsToJS: ['iter']
+});
+

--- a/src/__test__/groupBy-test.js
+++ b/src/__test__/groupBy-test.js
@@ -1,0 +1,40 @@
+// @flow
+import { fromJS, Record } from 'immutable';
+import groupBy from '../groupBy';
+import get from '../get';
+import compare from '../internal/__test__/compare-testutil';
+import compareIteratee from '../internal/__test__/compareIteratee-testutil';
+
+compare({
+    name: `groupBy() on object should work`,
+    item: {a: {type: "foo", value: 1}, b: {type: "bar", value: 2}, c: {type: "foo", value: 3}},
+    fn: groupBy(get('type')),
+    toJS: true
+});
+
+compareIteratee({
+    name: `groupBy() on object should pass correct arguments to iteratee`,
+    item: {a: {type: "foo", value: 1}, b: {type: "bar", value: 2}, c: {type: "foo", value: 3}},
+    fn: (checkArgs) => groupBy((value: *, key: *, iter: *): boolean => {
+        checkArgs({value, key, iter});
+        return get('type')(value);
+    }),
+    argsToJS: ['value','iter']
+});
+
+compare({
+    name: `groupBy() on array should work`,
+    item: [{type: "foo", value: 1}, {type: "bar", value: 2}, {type: "foo", value: 3}],
+    fn: groupBy(get('type')),
+    toJS: true
+});
+
+compareIteratee({
+    name: `groupBy() on array should pass correct arguments to iteratee`,
+    item: [{type: "foo", value: 1}, {type: "bar", value: 2}, {type: "foo", value: 3}],
+    fn: (checkArgs) => groupBy((value: *, key: *, iter: *): boolean => {
+        checkArgs({value, key, iter});
+        return get('type')(value);
+    }),
+    argsToJS: ['value', 'iter']
+});

--- a/src/__test__/hashCode-test.js
+++ b/src/__test__/hashCode-test.js
@@ -1,0 +1,36 @@
+// @flow
+import hashCode from '../hashCode';
+import {fromJS} from 'immutable';
+import {Record} from 'immutable';
+
+test(`hashCode() on object should work`, () => {
+    let hashCode1 = hashCode()({a:1, b:2, c:3});
+    let hashCode2 = hashCode()({a:1, b:2, c:3});
+    let hashCode3 = hashCode()({a:1, b:2, c:4});
+    expect(hashCode1).toBe(hashCode2);
+    expect(hashCode1).not.toBe(hashCode3);
+});
+
+test(`hashCode() on array should work`, () => {
+    let hashCode1 = hashCode()([1,2,3]);
+    let hashCode2 = hashCode()([1,2,3]);
+    let hashCode3 = hashCode()([1,2,3,undefined]);
+    expect(hashCode1).toBe(hashCode2);
+    expect(hashCode1).not.toBe(hashCode3);
+});
+
+test(`hashCode() on map should work`, () => {
+    let hashCode1 = hashCode()(fromJS({a:1, b:2, c:3}));
+    let hashCode2 = hashCode()(fromJS({a:1, b:2, c:3}));
+    let hashCode3 = hashCode()(fromJS({a:1, b:2, c:4}));
+    expect(hashCode1).toBe(hashCode2);
+    expect(hashCode1).not.toBe(hashCode3);
+});
+
+test(`hashCode() on list should work`, () => {
+    let hashCode1 = hashCode()(fromJS([1,2,3]));
+    let hashCode2 = hashCode()(fromJS([1,2,3]));
+    let hashCode3 = hashCode()(fromJS([1,2,3,undefined]));
+    expect(hashCode1).toBe(hashCode2);
+    expect(hashCode1).not.toBe(hashCode3);
+});

--- a/src/__test__/includes-test.js
+++ b/src/__test__/includes-test.js
@@ -1,0 +1,50 @@
+// @flow
+import {fromJS} from 'immutable';
+import includes from '../includes';
+import compare from '../internal/__test__/compare-testutil';
+
+compare({
+    name: `includes() on object should identify false result`,
+    item: {a:1, b:2, c:3, d:4},
+    fn: includes(5)
+});
+
+compare({
+    name: `includes() on object should identify true result`,
+    item: {a:1, b:2, c:3, d:4},
+    fn: includes(3)
+});
+
+compare({
+    name: `includes() on array should identify false result`,
+    item: [1,2,3,4],
+    fn: includes(0)
+});
+
+compare({
+    name: `includes() on array should identify true result`,
+    item: [1,2,3,4],
+    fn: includes(4)
+});
+
+test(`includes() should identify deeply equal result`, () => {
+
+    let data = [
+        [1,2],
+        [3,4],
+        [5,6]
+    ];
+
+    expect(includes([1,2])(data)).toBe(true);
+});
+
+test(`includes() should identify deeply equal result with immutable.js`, () => {
+
+    let data = fromJS([
+        [1,2],
+        [3,4],
+        [5,6]
+    ]);
+
+    expect(includes(fromJS([1,2]))(data)).toBe(true);
+});

--- a/src/__test__/notEquals-test.js
+++ b/src/__test__/notEquals-test.js
@@ -1,0 +1,17 @@
+// @flow
+import {fromJS} from 'immutable';
+import notEquals from '../notEquals';
+
+test(`notEquals() should do what it says on the tin when things are the same`, () => {
+    expect(notEquals({a:1,b:[2,3]})({a:1,b:[2,3]})).toBe(false);
+});
+test(`notEquals() should do what it says on the tin when things are not the same`, () => {
+    expect(notEquals({a:1,b:[2,3]})({a:1,b:[2,4]})).toBe(true);
+});
+
+test(`notEquals() should do what it says on the tin when immutable things are the same`, () => {
+    expect(notEquals(fromJS({a:1,b:[2,3]}))(fromJS({a:1,b:[2,3]}))).toBe(false);
+});
+test(`notEquals() should do what it says on the tin when immutable things are not the same`, () => {
+    expect(notEquals(fromJS({a:1,b:[2,3]}))(fromJS({a:1,b:[2,4]}))).toBe(true);
+});

--- a/src/__test__/unique-test.js
+++ b/src/__test__/unique-test.js
@@ -1,0 +1,75 @@
+// @flow
+import get from '../get';
+import unique from '../unique';
+import {fromJS} from 'immutable';
+
+test(`unique() on object should work`, () => {
+    let data = {
+        a: 1,
+        b: 2,
+        c: 1,
+        d: undefined,
+        e: 3,
+        f: undefined
+    };
+
+    let expectedData = {
+        a: 1,
+        b: 2,
+        d: undefined,
+        e: 3
+    };
+
+    expect(unique()(data)).toEqual(expectedData);
+});
+
+test(`unique() on map should work`, () => {
+    let data = fromJS({
+        a: 1,
+        b: 2,
+        c: 1,
+        d: 3
+    });
+
+    let expectedData = fromJS({
+        a: 1,
+        b: 2,
+        d: 3
+    });
+
+    expect(unique()(data)).toEqual(expectedData);
+});
+
+test(`unique() on array should work`, () => {
+    let data = [1,2,1,3,1,4];
+    let expectedData = [1,2,3,4];
+
+    expect(unique()(data)).toEqual(expectedData);
+});
+
+test(`unique() on array with uniqueness based on deep object equality`, () => {
+    let data = [
+        {abc: 123},
+        {abc: 456},
+        {def: 123},
+        {abc: 456},
+        {def: 789}
+    ];
+
+    let expectedData = [
+        {abc: 123},
+        {abc: 456},
+        {def: 123},
+        {def: 789}
+    ];
+
+    expect(unique()(data)).toEqual(expectedData);
+});
+
+
+test(`unique() on list should work`, () => {
+    let data = fromJS([1,2,1,3,1,4]);
+    let expectedData = [1,2,3,4];
+
+    expect(unique()(data).toJS()).toEqual(expectedData);
+});

--- a/src/__test__/uniqueBy-test.js
+++ b/src/__test__/uniqueBy-test.js
@@ -1,0 +1,86 @@
+// @flow
+import get from '../get';
+import uniqueBy from '../uniqueBy';
+import {fromJS} from 'immutable';
+
+test(`uniqueBy() on object should work`, () => {
+    let data = {
+        a: {type: "foo", value: 1},
+        b: {type: "bar", value: 2},
+        c: {type: "foo", value: 3}
+    };
+
+    let expectedData = {
+        a: {type: "foo", value: 1},
+        b: {type: "bar", value: 2}
+    };
+
+    expect(uniqueBy(get('type'))(data)).toEqual(expectedData);
+});
+
+test(`uniqueBy() on map should work`, () => {
+    let data = fromJS({
+        a: {type: "foo", value: 1},
+        b: {type: "bar", value: 2},
+        c: {type: "foo", value: 3}
+    });
+
+    let expectedData = {
+        a: {type: "foo", value: 1},
+        b: {type: "bar", value: 2}
+    };
+
+    expect(uniqueBy(get('type'))(data).toJS()).toEqual(expectedData);
+});
+
+test(`uniqueBy() on simple array should work`, () => {
+    let data = [1,2,1,3,1,4];
+    let expectedData = [1,2,3,4];
+
+    expect(uniqueBy(_ => _)(data)).toEqual(expectedData);
+});
+
+test(`uniqueBy() on array should work`, () => {
+    let data = [
+        {type: "foo", value: 1},
+        {type: "bar", value: 2},
+        {type: "foo", value: 3}
+    ];
+
+    let expectedData = [
+        {type: "foo", value: 1},
+        {type: "bar", value: 2}
+    ];
+
+    expect(uniqueBy(get('type'))(data)).toEqual(expectedData);
+});
+
+test(`uniqueBy() on array with uniqueness based on deep object equality`, () => {
+    let data = [
+        {type: {a:1,b:2}, value: 1},
+        {type: {a:2,b:2}, value: 2},
+        {type: {a:1,b:2}, value: 3}
+    ];
+
+    let expectedData = [
+        {type: {a:1,b:2}, value: 1},
+        {type: {a:2,b:2}, value: 2}
+    ];
+
+    expect(uniqueBy(get('type'))(data)).toEqual(expectedData);
+});
+
+test(`uniqueBy() on array should work`, () => {
+    let data = fromJS([
+        {type: "foo", value: 1},
+        {type: "bar", value: 2},
+        {type: "foo", value: 3}
+    ]);
+
+    let expectedData = [
+        {type: "foo", value: 1},
+        {type: "bar", value: 2}
+    ];
+
+    expect(uniqueBy(get('type'))(data).toJS()).toEqual(expectedData);
+});

--- a/src/forEach.js
+++ b/src/forEach.js
@@ -1,0 +1,19 @@
+// @flow
+import prep from './internal/prep';
+import entries from './entries';
+
+export default prep({
+    name: 'forEach',
+    immutable: 'forEach',
+    all: (sideEffect: Function) => (value: Object): number => {
+        let iterator = entries()(value);
+        let i = 0;
+        for(let [key, childValue] of iterator) {
+            i++;
+            if(sideEffect(childValue, key, value) === false) {
+                return i;
+            }
+        }
+        return i;
+    }
+});

--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -1,0 +1,24 @@
+// @flow
+import prep from './internal/prep';
+import reduce from './reduce';
+
+export default prep({
+    name: 'groupBy',
+    immutable: 'groupBy',
+    array: (grouper: Function) => reduce((grouped: *, ii: *, key: *, value: *) => {
+        let groupKey = grouper(ii, key, value);
+        if(!grouped[groupKey]) {
+            grouped[groupKey] = [];
+        }
+        grouped[groupKey].push(ii);
+        return grouped;
+    }, {}),
+    object: (grouper: Function) => reduce((grouped: *, ii: *, key: *, value: *) => {
+        let groupKey = grouper(ii, key, value);
+        if(!grouped[groupKey]) {
+            grouped[groupKey] = {};
+        }
+        grouped[groupKey][key] = ii;
+        return grouped;
+    }, {})
+});

--- a/src/hashCode.js
+++ b/src/hashCode.js
@@ -1,0 +1,8 @@
+// @flow
+import prep from './internal/prep';
+
+export default prep({
+    name: 'hashCode',
+    immutable: 'hashCode',
+    all: () => (value) => JSON.stringify(value)
+});

--- a/src/includes.js
+++ b/src/includes.js
@@ -1,0 +1,10 @@
+// @flow
+import prep from './internal/prep';
+import equals from './equals';
+import some from './some';
+
+export default prep({
+    name: 'includes',
+    immutable: 'includes',
+    all: (comparisonValue: *) => some(equals(comparisonValue))
+});

--- a/src/notEquals.js
+++ b/src/notEquals.js
@@ -1,0 +1,8 @@
+// @flow
+import prep from './internal/prep';
+import equals from './equals';
+
+export default prep({
+    name: 'notEquals',
+    all: (other) => (value) => !equals(other)(value)
+});

--- a/src/unique.js
+++ b/src/unique.js
@@ -1,0 +1,8 @@
+// @flow
+import prep from './internal/prep';
+import uniqueBy from './uniqueBy';
+
+export default prep({
+    name: 'unique',
+    all: () => uniqueBy(_ => _)
+});

--- a/src/uniqueBy.js
+++ b/src/uniqueBy.js
@@ -1,0 +1,35 @@
+// @flow
+import prep from './internal/prep';
+import hashCode from './hashCode';
+import every from './every';
+import filter from './filter';
+import notEquals from './notEquals';
+
+export default prep({
+    name: 'uniqueBy',
+    all: (getter: Function): Function => {
+        let hashes = {};
+        let values = [];
+        return filter((value: *, key: *, iter: *): boolean => {
+            let gotten = getter(value, key, iter);
+            let hash = hashCode()(gotten);
+            let isUnique = false;
+
+            if(!hashes[hash]) {
+                isUnique = true;
+            } else {
+                // if hash does already exist, its still not guaranteed
+                // that the current value has already been included in the output
+                // so all previous values must be checked deeply
+                isUnique = every(notEquals(gotten))(values);
+            }
+
+            if(isUnique) {
+                hashes[hash] = true;
+                values.push(gotten);
+                return true;
+            }
+            return false;
+        });
+    }
+});


### PR DESCRIPTION
- Add `forEach()`
- Add `groupBy()`
  - object and arrays cannot be grouped on deeply equal keys because plain objects cannot have objects as keys
- Add `hashCode()` 
- Add `includes()`
  - non-Immutable.js values are JSON stringified
- Add `notEquals()`
- Add `unique()` (#51)
- Add `uniqueBy()` (#51)
- No breaking changes
