### PR TITLE
Feature/uc tests

### DIFF
--- a/src/__test__/clear-test.js
+++ b/src/__test__/clear-test.js
@@ -6,7 +6,8 @@ compare({
     name: `clear() works on objects`,
     item: {a:1, b:2},
     fn: clear(),
-    toJS: true
+    toJS: true,
+    unmutableCompatible: true
 });
 
 compare({

--- a/src/__test__/clone-test.js
+++ b/src/__test__/clone-test.js
@@ -1,9 +1,11 @@
 // @flow
 import clone from '../clone';
 import {fromJS} from 'immutable';
+import UnmutableCompatible from '../internal/__test__/UnmutableCompatible-testutil';
 
 test(`clone() on object should work`, () => {
     let obj = {a:4, b:6};
+    expect(obj).toEqual(clone()(obj));
     expect(obj).not.toBe(clone()(obj));
 });
 
@@ -14,10 +16,17 @@ test(`clone() on Map should pass through`, () => {
 
 test(`clone() on array should work`, () => {
     let arr = [1,2,3];
+    expect(arr).toEqual(clone()(arr));
     expect(arr).not.toBe(clone()(arr));
 });
 
 test(`clone() on List should pass through`, () => {
     let list = fromJS([1,2,3]);
     expect(list).toBe(clone()(list));
+});
+
+test(`clone() on unnmutable compatible should work`, () => {
+    let uc = new UnmutableCompatible();
+    expect(uc.toObject()).toEqual(clone()(uc).toObject());
+    expect(uc).not.toBe(clone()(uc));
 });

--- a/src/__test__/delete-test.js
+++ b/src/__test__/delete-test.js
@@ -7,7 +7,8 @@ compare({
     item: {a:1, b:2},
     fn: del('a'),
     toJS: true,
-    record: true
+    record: true,
+    unmutableCompatible: true
 });
 
 compare({
@@ -15,7 +16,8 @@ compare({
     item: {a:1, b:2},
     fn: del('z'),
     toJS: true,
-    record: true
+    record: true,
+    unmutableCompatible: true
 });
 
 compare({

--- a/src/__test__/shallowToJS-test.js
+++ b/src/__test__/shallowToJS-test.js
@@ -1,6 +1,7 @@
 // @flow
 import shallowToJS from '../shallowToJS';
 import {fromJS} from 'immutable';
+import UnmutableCompatible from '../internal/__test__/UnmutableCompatible-testutil';
 
 let deepMap = fromJS({x:10,y:20});
 
@@ -10,6 +11,10 @@ test(`shallowToJS() should toJS() immutable lists only one level`, () => {
 
 test(`shallowToJS() should toJS() immutable maps only one level`, () => {
     expect(shallowToJS()(fromJS({a:1,b:2,c:deepMap}))).toEqual({a:1,b:2,c:deepMap});
+});
+
+test(`shallowToJS() should toJS() unmutable compatible only one level`, () => {
+    expect(shallowToJS()(new UnmutableCompatible({a:1,b:2,c:deepMap}))).toEqual({a:1,b:2,c:deepMap});
 });
 
 test(`shallowToJS() should pass through objects`, () => {

--- a/src/filter.js
+++ b/src/filter.js
@@ -1,8 +1,8 @@
 // @flow
 import prep from './internal/prep';
 import pipeWith from './util/pipeWith';
+import del from './delete'; // TODO - should be deleteMutate
 import entryArray from './entryArray';
-import reduce from './reduce';
 
 export default prep({
     name: 'filter',
@@ -10,15 +10,12 @@ export default prep({
     record: (predicate: Function) => (value: *): * => pipeWith(
         value,
         entryArray(),
-        reduce((record, [key, childValue]) => predicate(childValue, key, record) ? record : record.delete(key), value)
+        entries => entries.reduce((record, [key, childValue]) => predicate(childValue, key, record) ? record : record.delete(key), value)
     ),
-    object: (predicate: Function) => (value: Object): * => {
-        return Object
-            .keys(value)
-            .reduce((obj: Object, key: string): Object => {
-                let childValue = value[key];
-                return predicate(childValue, key, value) ? {...obj, [key]: childValue} : obj;
-            }, {});
-    },
-    array: (predicate: Function) => (value: Array<*>): * => value.filter(predicate)
+    array: (predicate: Function) => (value: Array<*>): * => value.filter(predicate),
+    all: (predicate: Function) => (value: *): * => pipeWith(
+        value,
+        entryArray(),
+        entries => entries.reduce((reduction, [key, childValue]) => predicate(childValue, key, value) ? reduction : del(key)(reduction), value)
+    )
 });

--- a/src/filterNot.js
+++ b/src/filterNot.js
@@ -1,24 +1,9 @@
 // @flow
 import prep from './internal/prep';
-import pipeWith from './util/pipeWith';
-import entryArray from './entryArray';
-import reduce from './reduce';
+import filter from './filter';
 
 export default prep({
     name: 'filterNot',
     immutable: 'filterNot',
-    record: (predicate: Function) => (value: *): * => pipeWith(
-        value,
-        entryArray(),
-        reduce((record, [key, value]) => predicate(value, key, record) ? record.delete(key) : record, value)
-    ),
-    object: (predicate: Function) => (value: Object): * => {
-        return Object
-            .keys(value)
-            .reduce((obj: Object, key: string): Object => {
-                let childValue = value[key];
-                return !predicate(childValue, key, value) ? {...obj, [key]: childValue} : obj;
-            }, {});
-    },
-    array: (predicate: Function) => (value: Array<*>): * => value.filter((...args) => !predicate(...args))
+    all: (predicate: Function) => filter((...args) => !predicate(...args))
 });

--- a/src/internal/__test__/UnmutableCompatible-testutil.js
+++ b/src/internal/__test__/UnmutableCompatible-testutil.js
@@ -1,7 +1,7 @@
 // @flow
 
 export default class UnmutableCompatible {
-    constructor(props: *) {
+    constructor(props: * = {}) {
         this._data = props;
     }
 
@@ -16,5 +16,7 @@ export default class UnmutableCompatible {
             [key]: childValue
         });
     };
+    clear = (): UnmutableCompatible => new UnmutableCompatible();
+    clone = (): UnmutableCompatible => new UnmutableCompatible(this._data);
     toObject = (): * => this._data;
 }

--- a/src/internal/__test__/UnmutableCompatible-testutil.js
+++ b/src/internal/__test__/UnmutableCompatible-testutil.js
@@ -1,4 +1,6 @@
 // @flow
+import set from '../../set';
+import del from '../../delete';
 
 export default class UnmutableCompatible {
     constructor(props: * = {}) {
@@ -10,12 +12,8 @@ export default class UnmutableCompatible {
 
     has = (key: string): boolean => this._data.hasOwnProperty(key);
     get = (key: string, notSetValue: *): * => this.has(key) ? this._data[key] : notSetValue;
-    set = (key: string, childValue: *): UnmutableCompatible => {
-        return new UnmutableCompatible({
-            ...this._data,
-            [key]: childValue
-        });
-    };
+    set = (key: string, childValue: *): UnmutableCompatible => new UnmutableCompatible(set(key, childValue)(this._data));
+    delete = (key: string): UnmutableCompatible => new UnmutableCompatible(del(key)(this._data));
     clear = (): UnmutableCompatible => new UnmutableCompatible();
     clone = (): UnmutableCompatible => new UnmutableCompatible(this._data);
     toObject = (): * => this._data;

--- a/src/internal/__test__/UnmutableCompatible-testutil.js
+++ b/src/internal/__test__/UnmutableCompatible-testutil.js
@@ -1,6 +1,7 @@
 // @flow
 import set from '../../set';
 import del from '../../delete';
+import entries from '../../entries';
 
 export default class UnmutableCompatible {
     constructor(props: * = {}) {
@@ -16,5 +17,6 @@ export default class UnmutableCompatible {
     delete = (key: string): UnmutableCompatible => new UnmutableCompatible(del(key)(this._data));
     clear = (): UnmutableCompatible => new UnmutableCompatible();
     clone = (): UnmutableCompatible => new UnmutableCompatible(this._data);
+    entries = () => entries()(this._data);
     toObject = (): * => this._data;
 }

--- a/src/internal/__test__/unmutableCompatible-test.js
+++ b/src/internal/__test__/unmutableCompatible-test.js
@@ -1,0 +1,146 @@
+// @flow
+var fs = require('fs');
+import * as src from '../../../index';
+import UnmutableCompatible from './UnmutableCompatible-testutil';
+
+let files = {
+    // butLast: [],
+    // chunkBy: [],
+    // chunk: [],
+    clear: [],
+    clone: [],
+    // concat: [],
+    // count: [],
+    // deal: [],
+    // defaults: [],
+    // deleteAll: [],
+    deleteIn: [['def', 'ghi']],
+    delete: ['abc'],
+    doIf: [],
+    entries: [],
+    // entriesReverse: [],
+    entryArray: [],
+    // equals: [],
+    // every: [],
+    filter: [_ => _],
+    // filterNot: [],
+    // findEntry: [],
+    // findIndex: [],
+    // find: [],
+    // findKey: [],
+    // findLastEntry: [],
+    // findLastIndex: [],
+    // findLast: [],
+    // findLastKey: [],
+    // first: [],
+    // flatMap: [],
+    // flatten: [],
+    // forEach: [],
+    getIn: [['def', 'ghi']],
+    get: ['abc'],
+    // groupBy: [],
+    // hashCode: [],
+    hasIn: [['def', 'ghi']],
+    has: ['abc'],
+    identity: [],
+    // includes: [],
+    // indexOf: [],
+    // insert: [],
+    // interpose: [],
+    // isEmpty: [],
+    // isNotEmpty: [],
+    // join: [],
+    keyArray: [],
+    // keyBy: [],
+    // keyOf: [],
+    keys: [],
+    // lastIndexOf: [],
+    // last: [],
+    // lastKeyOf: [],
+    log: [],
+    map: [_ => _],
+    // maxBy: [],
+    // max: [],
+    // mergeDeepIn: [],
+    // mergeDeep: [],
+    // mergeDeepWith: [],
+    // mergeIn: [],
+    // merge: [],
+    // mergeWith: [],
+    // minBy: [],
+    // min: [],
+    // move: [],
+    // notEquals: [],
+    // omit: [],
+    // pick: [['abc']],
+    // pivot: [],
+    // pop: [],
+    // push: [],
+    reduce: [_ => _, {}],
+    // reduceRight: [],
+    // rename: [],
+    // rest: [],
+    // reverse: [],
+    // rotate: [],
+    setIn: [['def', 'ghi'], 789],
+    set: ['abc', 789],
+    // setSize: [],
+    // shallowEquals: [],
+    // shallowToJS: [],
+    // shift: [],
+    // size: [],
+    // skip: [],
+    // skipLast: [],
+    // skipUntil: [],
+    // skipWhile: [],
+    // slice: [],
+    // some: [],
+    // sortBy: [],
+    // sort: [],
+    // splice: [],
+    // strictEquals: [],
+    // swap: [],
+    // take: [],
+    // takeLast: [],
+    // takeUntil: [],
+    // takeWhile: [],
+    // toArray: [],
+    // toIndexed: [],
+    // toJS: [],
+    // toJSON: [],
+    // toKeyed: [],
+    toObject: [],
+    // uniqueBy: [],
+    // unique: [],
+    // unit: [],
+    // unshift: [],
+    updateIn: [['def', 'ghi'], _ => _],
+    // updateInto: [],
+    update: ['abc', _ => _],
+    valueArray: [],
+    values: [],
+    // zipAll: [],
+    // zip: [],
+    // zipWith: []
+};
+
+let value = new UnmutableCompatible({
+    abc: 123,
+    def: {
+        ghi: 456
+    }
+});
+
+Object.keys(files).forEach((file) => {
+    test(`Unmutable Compatible should be able to call ${file}`, () => {
+        let fn = src[file](...files[file]);
+        let passed = true;
+        try {
+            fn(value);
+        } catch(e) {
+            console.log(`Error running Unmutable Compatible ${file}:`, e.message);
+            passed = false;
+        }
+        expect(passed).toBe(true);
+    });
+});

--- a/src/internal/__test__/unmutableCompatible-test.js
+++ b/src/internal/__test__/unmutableCompatible-test.js
@@ -16,7 +16,7 @@ let files = {
     // deleteAll: [],
     deleteIn: [['def', 'ghi']],
     delete: ['abc'],
-    doIf: [],
+    doIf: [() => true, _ => _, _ => _],
     entries: [],
     // entriesReverse: [],
     entryArray: [],

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,27 +1,28 @@
 // @flow
 import prep from './internal/prep';
+import entries from './entries';
 
 export default prep({
     name: "keys",
     immutable: "keys",
     record: () => (value: *) => value.toSeq().keys(),
+    array: () => (value: Array<*>): * => value.keys(),
     // $FlowFixMe - flow cannot recognise Symbol.iterator (see https://github.com/facebook/flow/issues/1163)
-    object: () => (value: Object): * => {
-        let counter = 0;
-        const keys = Object.keys(value);
+    all: () => (value: Object): * => {
+        let entryIterator = entries()(value);
         return {
             [Symbol.iterator]: function(): Object {
                 return this;
             },
-            next: () => keys.hasOwnProperty(counter)
-                ? ({
-                    value: keys[counter++],
-                    done: false
-                })
-                : ({
-                    done: true
-                })
+            next: () => {
+                let entry = entryIterator.next();
+                return entry.done
+                    ? entry
+                    : {
+                        done: false,
+                        value: entry.value[0]
+                    };
+            }
         };
-    },
-    array: () => (value: Array<*>): * => value.keys()
+    }
 });

--- a/src/map.js
+++ b/src/map.js
@@ -2,8 +2,7 @@
 import prep from './internal/prep';
 import pipeWith from './util/pipeWith';
 import entryArray from './entryArray';
-import reduce from './reduce';
-
+import set from './set'; // TODO - should be setMutate
 
 export default prep({
     name: 'map',
@@ -11,15 +10,12 @@ export default prep({
     record: (mapper: Function) => (value: *): * => pipeWith(
         value,
         entryArray(),
-        reduce((record, [key, value]) => record.set(key, mapper(value, key, record)), value)
+        entries => entries.reduce((record, [key, childValue]) => record.set(key, mapper(childValue, key, record)), value)
     ),
-    object: (mapper: Function) => (value: Object): * => {
-        return Object
-            .keys(value)
-            .reduce((obj: Object, key: string): Object => {
-                obj[key] = mapper(value[key], key, value);
-                return obj;
-            }, {});
-    },
-    array: (mapper: Function) => (value: Array<*>): * => value.map(mapper)
+    array: (mapper: Function) => (value: Array<*>): * => value.map(mapper),
+    all: (mapper: Function) => (value: Object): * => pipeWith(
+        value,
+        entryArray(),
+        entries => entries.reduce((reduction, [key, childValue]) => set(key, mapper(childValue, key, value))(reduction), value)
+    )
 });

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -2,24 +2,14 @@
 import prep from './internal/prep';
 import pipeWith from './util/pipeWith';
 import entryArray from './entryArray';
-import reduce from './reduce';
-
 
 export default prep({
     name: 'reduce',
     immutable: 'reduce',
-    record: (reducer: Function, initialReduction: *) => (value: *): * => pipeWith(
+    array: (reducer: Function, initialReduction: *) => (value: Array<*>): * => value.reduce(reducer, initialReduction),
+    all: (reducer: Function, initialReduction: *) => (value: *): * => pipeWith(
         value,
         entryArray(),
-        reduce((reduction, [key, childValue]) => reducer(reduction, childValue, key, value), initialReduction)
-    ),
-    object: (reducer: Function, initialReduction: *) => (value: Object): * => {
-        return Object
-            .keys(value)
-            .reduce(
-                (reduction, key) => reducer(reduction, value[key], key, value),
-                initialReduction
-            );
-    },
-    array: (reducer: Function, initialReduction: *) => (value: Array<*>): * => value.reduce(reducer, initialReduction)
+        entries => entries.reduce((reduction, [key, childValue]) => reducer(reduction, childValue, key, value), initialReduction)
+    )
 });

--- a/src/shallowToJS.js
+++ b/src/shallowToJS.js
@@ -3,6 +3,6 @@ import prep from './internal/prep';
 import toJSON from './toJSON';
 
 export default prep({
-    name: 'deleteAll',
+    name: 'shallowToJS',
     all: toJSON
 });

--- a/src/toJSON.js
+++ b/src/toJSON.js
@@ -1,9 +1,11 @@
 // @flow
 import prep from './internal/prep';
-import identity from './identity';
+import toArray from './toArray';
+import toObject from './toObject';
+import isIndexed from './util/isIndexed';
 
 export default prep({
     name: "toJSON",
     immutable: "toJSON",
-    all: () => identity()
+    all: () => (value) => isIndexed(value) ? toArray()(value) : toObject()(value)
 });

--- a/src/values.js
+++ b/src/values.js
@@ -1,28 +1,29 @@
 // @flow
 import prep from './internal/prep';
+import entries from './entries';
 
 export default prep({
     name: "values",
     immutable: "values",
     record: () => (value) => value.toSeq().values(),
+    // $FlowFixMe - flow can't deal with computed properties
+    array: () => (value: Array<*>): * => value[Symbol.iterator](),
     // $FlowFixMe - using * as flow cannot recognise Symbol.iterator as being @@iterator (see https://github.com/facebook/flow/issues/1163)
-    object: () => (value: Object): * => {
-        let counter = 0;
-        const keys = Object.keys(value);
+    all: () => (value: Object): * => {
+        let entryIterator = entries()(value);
         return {
             [Symbol.iterator]: function(): Object {
                 return this;
             },
-            next: () => keys.hasOwnProperty(counter)
-                ? ({
-                    value: value[keys[counter++]],
-                    done: false
-                })
-                : ({
-                    done: true
-                })
+            next: () => {
+                let entry = entryIterator.next();
+                return entry.done
+                    ? entry
+                    : {
+                        done: false,
+                        value: entry.value[1]
+                    };
+            }
         };
-    },
-    // $FlowFixMe - flow can't deal with computed properties
-    array: () => (value: Array<*>): * => value[Symbol.iterator]()
+    }
 });


### PR DESCRIPTION
- Fixed shallowToJS, internal name was wrong
- Refactor: restore previous shallowToJS logic that can cope with non array non object types
- Refactor: make keys and values use entries internally
- Add unmutable compatible tests to identify base functions for UnmutableCompatible types
- Feat: make filter, filterNot, map and reduce able to be called on unmutable compatible data, and remove record specific implementations
- Test: allow unmutable compatible tests to check clear, clone and delete
- No breaking changes