### PR TITLE
fix: reduce and reduceRight should work without initial reductions

### DIFF
--- a/packages/unmutable/src/__test__/reduce-test.js
+++ b/packages/unmutable/src/__test__/reduce-test.js
@@ -11,6 +11,37 @@ compare({
     record: true
 });
 
+compare({
+    name: `reduce() on object should work when only one item`,
+    item: {a:1},
+    fn: reduce((reduction, value) => [...reduction, value], [])
+});
+
+compare({
+    name: `reduce() on object should work when empty`,
+    item: {a:1},
+    fn: reduce((reduction, value) => [...reduction, value], [])
+});
+
+compare({
+    name: `reduce() on object should work without initial reduction`,
+    item: {a:1, b:2, c:3, d:4},
+    fn: reduce((a, b) => a - b)
+});
+
+compare({
+    name: `reduce() on object should work without initial reduction when only one item`,
+    item: {a: 1},
+    fn: reduce((a, b) => a - b)
+});
+
+
+compare({
+    name: `reduce() on object should work without initial reduction when empty`,
+    item: {},
+    fn: reduce((a, b) => a - b)
+});
+
 compareIteratee({
     name: `reduce() on object should pass correct arguments to iteratee`,
     item: {a:1, b:2, c:3, d:4},
@@ -25,6 +56,12 @@ compare({
     name: `reduce() on array should work`,
     item:[1,2,3,4],
     fn: reduce((reduction, value) => [value, ...reduction], [])
+});
+
+compare({
+    name: `reduce() on array should work without initial reduction`,
+    item:[1,2,3,4],
+    fn: reduce((a, b) => a - b)
 });
 
 compareIteratee({

--- a/packages/unmutable/src/__test__/reduce-test.js
+++ b/packages/unmutable/src/__test__/reduce-test.js
@@ -19,7 +19,7 @@ compare({
 
 compare({
     name: `reduce() on object should work when empty`,
-    item: {a:1},
+    item: {},
     fn: reduce((reduction, value) => [...reduction, value], [])
 });
 

--- a/packages/unmutable/src/__test__/reduceRight-test.js
+++ b/packages/unmutable/src/__test__/reduceRight-test.js
@@ -9,6 +9,24 @@ compare({
     fn: reduceRight((reduction, value) => [...reduction, value], [])
 });
 
+compare({
+    name: `reduceRight() on object should work without initial reduction`,
+    item: {a:1, b:2, c:3, d:4},
+    fn: reduceRight((a, b) => a - b)
+});
+
+compare({
+    name: `reduceRight() on object should work without initial reduction when only one item`,
+    item: {a:1},
+    fn: reduceRight((a, b) => a - b)
+});
+
+compare({
+    name: `reduceRight() on object should work without initial reduction when empty`,
+    item: {},
+    fn: reduceRight((a, b) => a - b)
+});
+
 compareIteratee({
     name: `reduceRight() on object should pass correct arguments to iteratee`,
     item: {a:1, b:2, c:3, d:4},
@@ -23,6 +41,12 @@ compare({
     name: `reduceRight() on array should work`,
     item:[1,2,3,4],
     fn: reduceRight((reduction, value) => [value, ...reduction], [])
+});
+
+compare({
+    name: `reduceRight() on array should work without initial reduction`,
+    item:[1,2,3,4],
+    fn: reduceRight((a, b) => a - b)
 });
 
 compareIteratee({

--- a/packages/unmutable/src/__test__/reduceRight-test.js
+++ b/packages/unmutable/src/__test__/reduceRight-test.js
@@ -10,6 +10,20 @@ compare({
 });
 
 compare({
+    name: `reduceRight() on object should work when only one item`,
+    item: {a:1},
+    fn: reduceRight((reduction, value) => [...reduction, value], [])
+});
+
+
+compare({
+    name: `reduceRight() on object should work when empty`,
+    item: {},
+    fn: reduceRight((reduction, value) => [...reduction, value], [])
+});
+
+
+compare({
     name: `reduceRight() on object should work without initial reduction`,
     item: {a:1, b:2, c:3, d:4},
     fn: reduceRight((a, b) => a - b)

--- a/packages/unmutable/src/reduce.js
+++ b/packages/unmutable/src/reduce.js
@@ -6,10 +6,24 @@ import entryArray from './entryArray';
 export default prep({
     name: 'reduce',
     immutable: 'reduce',
-    array: (reducer: Function, initialReduction: *) => (value: Array<*>): * => value.reduce(reducer, initialReduction),
-    all: (reducer: Function, initialReduction: *) => (value: *): * => pipeWith(
-        value,
-        entryArray(),
-        entries => entries.reduce((reduction, [key, childValue]) => reducer(reduction, childValue, key, value), initialReduction)
-    )
+    array: (reducer: Function, ...initialReduction: *[]) => (value: Array<*>): * => {
+        return initialReduction.length
+            ? value.reduce(reducer, initialReduction[0])
+            : value.reduce(reducer);
+    },
+    all: (reducer: Function, ...initialReduction: *[]) => (value: *): * => {
+        let fn = (reduction, [key, childValue]) => reducer(reduction, childValue, key, value);
+        return pipeWith(
+            value,
+            entryArray(),
+            entries => {
+                if(initialReduction.length) {
+                    return entries.reduce(fn, initialReduction[0]);
+                }
+                return entries.length
+                    ? entries.slice(1).reduce(fn, entries[0][1])
+                    : undefined;
+            }
+        );
+    }
 });

--- a/packages/unmutable/src/reduceRight.js
+++ b/packages/unmutable/src/reduceRight.js
@@ -1,16 +1,29 @@
 // @flow
 import prep from './internal/unmutable';
+import pipeWith from './util/pipeWith';
+import entryArray from './entryArray';
 
 export default prep({
     name: 'reduceRight',
     immutable: 'reduceRight',
-    object: (reducer: Function, initialReduction: *) => (value: Object): * => {
-        return Object
-            .keys(value)
-            .reduceRight(
-                (reduction, key) => reducer(reduction, value[key], key, value),
-                initialReduction
-            );
+    array: (reducer: Function, ...initialReduction: *[]) => (value: Array<*>): * => {
+        return initialReduction.length
+            ? value.reduceRight(reducer, initialReduction[0])
+            : value.reduceRight(reducer);
     },
-    array: (reducer: Function, initialReduction: *) => (value: Array<*>): * => value.reduceRight(reducer, initialReduction)
+    all: (reducer: Function, ...initialReduction: *[]) => (value: *): * => {
+        let fn = (reduction, [key, childValue]) => reducer(reduction, childValue, key, value);
+        return pipeWith(
+            value,
+            entryArray(),
+            entries => {
+                if(initialReduction.length) {
+                    return entries.reduceRight(fn, initialReduction[0]);
+                }
+                return entries.length
+                    ? entries.slice(0,-1).reduceRight(fn, entries[entries.length - 1][1])
+                    : undefined;
+            }
+        );
+    }
 });


### PR DESCRIPTION
- fix: reduce and reduceRight should work without initial reductions

Extra tests with single elements and no elements are to ensure parity with Immutable.js which behaves a little differently with empty arrays with no initial reduction:

![image](https://user-images.githubusercontent.com/345320/53389754-a3815680-39e4-11e9-9e5b-f698f6baf034.png)
