### PR TITLE
Feature/equals type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 lib
 node_modules
 *.log
+.cache
+docs

--- a/packages/unmutable-docs/gatsby-browser.js
+++ b/packages/unmutable-docs/gatsby-browser.js
@@ -1,3 +1,0 @@
-/* eslint-disable */
-import * as UnmutableMethods from 'unmutable';
-window.Unmutable = UnmutableMethods;

--- a/packages/unmutable-docs/src/component/Example.jsx
+++ b/packages/unmutable-docs/src/component/Example.jsx
@@ -13,6 +13,10 @@ import join from 'unmutable/lib/join';
 import keyArray from 'unmutable/lib/keyArray';
 import map from 'unmutable/lib/map';
 
+if(typeof window !== "undefined") {
+    window.Unmutable = UnmutableMethods;
+}
+
 // import Prism from 'prismjs';
 
 // require(`prismjs/components/prism-flow.js`);

--- a/packages/unmutable-docs/src/pages/api/index.js
+++ b/packages/unmutable-docs/src/pages/api/index.js
@@ -522,7 +522,8 @@ update(updater: (collection: any) => any) => (collection) => newCollection`,
                     {
                         name: "equals()",
                         definition: "`equals(otherValue) => (value) => boolean`",
-                        description: "Returns `true` if `value` and `otherValue` are deeply equal, or `false` otherwise."
+                        description: "Returns `true` if `value` and `otherValue` are deeply equal, or `false` otherwise.",
+                        note: "This function compares items by value, so two different class instances containing the same data in the same manner (e.g. an array and an Immutable.js List) will be regarded as equal. Consider also using equalsType() if this is a problem for you."
                     },
                     {
                         name: "notEquals()",
@@ -531,18 +532,23 @@ update(updater: (collection: any) => any) => (collection) => newCollection`,
                     },
                     {
                         name: "strictEquals()",
-                        definition: "strictEquals(otherCollection: *) => (collection) => number",
+                        definition: "strictEquals(otherCollection: any) => (collection: any) => number",
                         description: "Checks if `collection` and `otherCollection` are strictly equal. This complements `equals()`, which checks for deep value equality."
                     },
                     {
                         name: "shallowEquals()",
-                        definition: "shallowEquals(otherCollection: *) => (collection) => number",
+                        definition: "shallowEquals(otherCollection: any) => (collection: any) => number",
                         description: "Checks if `collection` and `otherCollection` are shallowly equal, using strict equality.",
                         note: "Use `equals()` if you want to check deep equality."
                     },
                     {
                         name: "hashCode()",
                         description: ""
+                    },
+                    {
+                        name: "equalsType()",
+                        definition: "`equalsType(otherValue: any) => (value: any) => boolean`",
+                        description: "Returns `true` if `value` and `otherValue` are of the same type, or `false` otherwise. Class instances only count as equal if they are instances of the same class. Also unlike the type returned by `typeof`, `null` is *not* equal to objects, and are only equal to `null`."
                     }
                 ])
             },

--- a/packages/unmutable/.gitignore
+++ b/packages/unmutable/.gitignore
@@ -19,6 +19,7 @@
 /entriesReverse.js
 /entryArray.js
 /equals.js
+/equalsType.js
 /every.js
 /filter.js
 /filterNot.js

--- a/packages/unmutable/index.js
+++ b/packages/unmutable/index.js
@@ -17,6 +17,7 @@ export {default as entries} from './lib/entries';
 export {default as entriesReverse} from './lib/entriesReverse';
 export {default as entryArray} from './lib/entryArray';
 export {default as equals} from './lib/equals';
+export {default as equalsType} from './lib/equalsType';
 export {default as every} from './lib/every';
 export {default as filter} from './lib/filter';
 export {default as filterNot} from './lib/filterNot';

--- a/packages/unmutable/package.json
+++ b/packages/unmutable/package.json
@@ -22,6 +22,7 @@
     "entriesReverse.js",
     "entryArray.js",
     "equals.js",
+    "equalsType.js",
     "every.js",
     "filter.js",
     "filterNot.js",

--- a/packages/unmutable/src/__test__/equalsType-test.js
+++ b/packages/unmutable/src/__test__/equalsType-test.js
@@ -1,0 +1,22 @@
+// @flow
+import testTypes from '../internal/__test__/testTypes-testutil';
+import {typeFactory} from '../internal/__test__/testTypes-testutil';
+import equalsType from '../equalsType';
+
+let types = typeFactory();
+const typeNames = Object.keys(types);
+
+typeNames.forEach((type) => {
+    let expectedResult = {};
+    typeNames.forEach((tt) => {
+        expectedResult[tt] = false;
+    });
+
+    expectedResult[type] = true;
+
+    testTypes({
+        name: `equalsType() on ${type} should work`,
+        fn: (value) => equalsType(value)(types[type]),
+        expectedResult
+    });
+});

--- a/packages/unmutable/src/__test__/replaceEqualDeep-test.js
+++ b/packages/unmutable/src/__test__/replaceEqualDeep-test.js
@@ -80,3 +80,19 @@ test(`replaceEqualDeep() on object should work when a child is deeply equal`, ()
     expect(replaceEqualDeep(data)(newDataDifferent).b).toBe(data.b);
     expect(replaceEqualDeep(data)(newDataDifferent).b).toEqual(data.b);
 });
+
+test(`replaceEqualDeep() should cope with children of different types`, () => {
+    let data = {
+        a: 1,
+        b: 123
+    };
+
+    let newDataDifferent = {
+        a: 10,
+        b: {
+            c: 2
+        }
+    };
+
+    expect(replaceEqualDeep(data)(newDataDifferent)).toEqual(newDataDifferent);
+});

--- a/packages/unmutable/src/equalsType.js
+++ b/packages/unmutable/src/equalsType.js
@@ -1,0 +1,24 @@
+// @flow
+import prep from './internal/unmutable';
+import isObject from './isObject';
+
+export default prep({
+    name: 'equalsType',
+    all: (other: *) => (value: *): boolean => {
+        if(typeof value !== typeof other) {
+            return false;
+        }
+
+        let valueIsNull = value === null;
+        let otherIsNull = other === null;
+        if(valueIsNull || otherIsNull) {
+            return otherIsNull === valueIsNull;
+        }
+
+        if(isObject(value) && isObject(other)) {
+            return value.constructor === other.constructor;
+        }
+
+        return true;
+    }
+});

--- a/packages/unmutable/src/internal/__test__/testTypes-testutil.js
+++ b/packages/unmutable/src/internal/__test__/testTypes-testutil.js
@@ -27,38 +27,41 @@ class ABRecordExtended3 extends ABRecord3 {}
 
 class A {}
 
+export const typeFactory = () => ({
+    undefined: undefined,
+    null: null,
+    string: "string",
+    number: 123,
+    object: {object: true},
+    array: ["array"],
+    map: Map(),
+    orderedMap: OrderedMap(),
+    list: List(),
+    record: new ABRecord({b: 3}),
+    recordExtended: new ABRecordExtended({b: 3}),
+    set: Set(),
+    orderedSet: OrderedSet(),
+    seq: Seq(),
+    stack: Stack(),
+    map3: Map3(),
+    orderedMap3: OrderedMap3(),
+    list3: List3(),
+    record3: new ABRecord3({b: 3}),
+    recordExtended3: new ABRecordExtended3({b: 3}),
+    set3: Set3(),
+    orderedSet3: OrderedSet3(),
+    seq3: Seq3(),
+    stack3: Stack3(),
+    function: () => {},
+    classInstance: new A(),
+    unmutableCompatible: new UnmutableCompatible()
+});
+
+
+
 export default ({name, fn, expectedResult}: TestTypesConfig) => {
 
-    const types = {
-        undefined: undefined,
-        null: null,
-        string: "string",
-        number: 123,
-        object: {object: true},
-        array: ["array"],
-        map: Map(),
-        orderedMap: OrderedMap(),
-        list: List(),
-        record: new ABRecord({b: 3}),
-        recordExtended: new ABRecordExtended({b: 3}),
-        set: Set(),
-        orderedSet: OrderedSet(),
-        seq: Seq(),
-        stack: Stack(),
-        map3: Map3(),
-        orderedMap3: OrderedMap3(),
-        list3: List3(),
-        record3: new ABRecord3({b: 3}),
-        recordExtended3: new ABRecordExtended3({b: 3}),
-        set3: Set3(),
-        orderedSet3: OrderedSet3(),
-        seq3: Seq3(),
-        stack3: Stack3(),
-        function: () => {},
-        classInstance: new A(),
-        unmutableCompatible: new UnmutableCompatible()
-    };
-
+    let types = typeFactory();
     // $HackityHacks: call function type to get 100% coverage
     types.function();
 
@@ -68,6 +71,6 @@ export default ({name, fn, expectedResult}: TestTypesConfig) => {
     }), {});
 
     test(name, () => {
-        expect(expectedResult).toEqual(result);
+        expect(result).toEqual(expectedResult);
     });
 };

--- a/packages/unmutable/src/replaceEqualDeep.js
+++ b/packages/unmutable/src/replaceEqualDeep.js
@@ -1,6 +1,7 @@
 // @flow
 import prep from './internal/unmutable';
 import equals from './equals';
+import equalsType from './equalsType';
 import get from './get';
 import map from './map';
 import pipeWith from './pipeWith';
@@ -10,16 +11,16 @@ const replaceEqualDeep = (other: any) => (collection: *): * => {
     if(equals(other)(collection)) {
         return other;
     }
-    if(isWriteable(collection)) {
-        return pipeWith(
-            collection,
-            map((child, key) => {
-                let otherChild = get(key)(other);
-                return replaceEqualDeep(otherChild)(child);
-            })
-        );
+    if(!isWriteable(collection) || !equalsType(other)(collection)) {
+        return collection;
     }
-    return collection;
+    return pipeWith(
+        collection,
+        map((child, key) => {
+            let otherChild = get(key)(other);
+            return replaceEqualDeep(otherChild)(child);
+        })
+    );
 };
 
 export default prep({


### PR DESCRIPTION
Addresses #105

- fix: `replaceEqualsDeep()` was erroring out when passed a deep collection on one side and a non-collection on the other. It now check for type differences before descending when looking for deep similarities, and bails if types do not match #105
- add: `equalsType()`
- No breaking changes