### PR TITLE
fix: set() did not correctly set new negative index values

### DIFF
--- a/packages/unmutable/src/__test__/set-test.js
+++ b/packages/unmutable/src/__test__/set-test.js
@@ -36,8 +36,23 @@ compare({
 });
 
 compare({
-    name: `set() array sets a negative value`,
+    name: `set() array sets an existing negative value`,
     item: [1,2,3],
     fn: set(-2, 123),
     toJS: true
 });
+
+compare({
+    name: `set() array sets a new negative value`,
+    item: [],
+    fn: set(-1, 123),
+    toJS: true
+});
+
+compare({
+    name: `set() array sets a new negative value with existing values`,
+    item: [1,2,3],
+    fn: set(-5, 123),
+    toJS: true
+});
+

--- a/packages/unmutable/src/set.js
+++ b/packages/unmutable/src/set.js
@@ -5,6 +5,7 @@ export const objectSet = (key: string, childValue: *) => (value: Object): Object
 
 export const arraySet = (key: number, childValue: *) => (value: Array<*>): Array<*> => {
     key = key < 0 ? key + value.length : key;
+    if(key < 0) return [childValue, ...Array(-key-1), ...value];
     let clone = [...value];
     clone[key] = childValue;
     return clone;


### PR DESCRIPTION
Bug fix for `set()` with new negative index values like `set(-4, 'hello')(['a','b'])`